### PR TITLE
Error handling changes

### DIFF
--- a/er3t/util/util.py
+++ b/er3t/util/util.py
@@ -731,6 +731,11 @@ def download_laads_https(
                     msg = '\nError [download_laads_https]: To use \'download_laads_https\', \'pyhdf\' needs to be installed.'
                     raise ImportError(msg)
 
+                #\----------------------------------------------------------------------------/#
+                # Attempt to download files. In case of an HDF4Error, attempt to re-download
+                # afer a time period as this could be caused by an internal timeout at
+                # the server side
+                #/----------------------------------------------------------------------------\#
                 try:
                     print('Message [download_laads_https]: Reading \'%s\' ...\n' % fname_local)
                     f = SD(fname_local, SDC.READ)

--- a/er3t/util/util.py
+++ b/er3t/util/util.py
@@ -726,12 +726,31 @@ def download_laads_https(
 
                 try:
                     from pyhdf.SD import SD, SDC
+                    import pyhdf
+                except ImportError:
+                    msg = '\nError [download_laads_https]: To use \'download_laads_https\', \'pyhdf\' needs to be installed.'
+                    raise ImportError(msg)
+
+                try:
+                    print('Message [download_laads_https]: Reading \'%s\' ...\n' % fname_local)
                     f = SD(fname_local, SDC.READ)
                     f.end()
-                    print('Message [download_laads_https]: <%s> has been downloaded.\n' % fname_local)
-                except:
-                    msg = '\nWarning [download_laads_https]: Do not support check for <.%s> file.\nDo not know whether <%s> has been successfully downloaded.\n' % (data_format, fname_local)
-                    warnings.warn(msg)
+                    print('Message [download_laads_https]: \'%s\' has been downloaded.\n' % fname_local)
+
+                except pyhdf.error.HDF4Error:
+                    print('Message [download_laads_https]: Encountered an error with \'%s\', trying again ...\n' % fname_local)
+                    try:
+                        os.remove(fname_local)
+                        time.sleep(10) # wait 10 seconds
+                        os.system(command) # re-download
+                        f = SD(fname_local, SDC.READ)
+                        f.end()
+                        print('Message [download_laads_https]: \'%s\' has been downloaded.\n' % fname_local)
+                    except pyhdf.error.HDF4Error:
+                        print('Message [download_laads_https]: WARNING: Failed to read \'%s\'. File will be deleted as it might not be downloaded correctly. \n' % fname_local)
+                        fnames_local.remove(fname_local)
+                        os.remove(fname_local)
+                        continue
 
 
             elif data_format == 'nc':


### PR DESCRIPTION
This PR has a total of 2 error-handling recommendations:

1. Commit `2795cf2` addresses the issue of accessing the metadata files. Currently, despite correct usage, server issues are not communicated by the DAAC API efficiently. This commit will download the file locally instead of accessing it online which seemed to be causing the issue.

2. Commits `0a9eda7` and `f76bee1` add similar error handling to the above but during downloading of files. Sometimes, due to an internal timeout, files are not downloaded fully and therefore cause issues when attempting to read them. These commits attempt to solve the issue by attempting to re-download the files and in case of failure, the incomplete files are deleted. Please note that this is a drastic measure as it deletes a file. A safer alternative could be to just print to stdout the names of the corrupt files so the user is aware of them instead of deleting the files.