### PR TITLE
CLI for MODIS Products

### DIFF
--- a/bin/download_modis
+++ b/bin/download_modis
@@ -10,8 +10,8 @@ Authors:
     Modified by Vikas Nataraja.
 
 Example Usage:
-    download_modis --date 20210523 --lon 30 --lat 0 --satellite aqua --product mod06_l2 --fdir_out tmp-data/
-    download_modis --date 20130714 --extent 30 35 0 10 --satellite terra --product modl1b --fdir_out tmp-data/
+    download_modis --date 20210523 --lons 30 35 --lats 0 10 --satellite aqua --products 06_l2 --fdir tmp-data/
+    download_modis --date 20130714 --extent 30 35 0 10 --satellite terra --products rgb 02hkm 06_l2 --fdir tmp-data/
 """
 
 import os
@@ -19,7 +19,7 @@ import sys
 import pickle
 import h5py
 from pyhdf.SD import SD, SDC
-from argparse import ArgumentParser, RawTextHelpFormatter,  RawDescriptionHelpFormatter
+from argparse import ArgumentParser, RawTextHelpFormatter
 import numpy as np
 import datetime
 
@@ -32,11 +32,11 @@ description = '=================================================================
               '===================================================================\n'\
               '================ MODIS Data Product Download Tool =================\n'\
               'Example Usage:\n'\
-              'download_modis --date 20210523 --lon 30 35 --lat 0 10 --satellite aqua --product mod06_l2 --fdir_out tmp-data/\n'\
-              'download_modis --date 20130714 --extent 30 35 0 10 --satellite terra --product modl1b --fdir_out tmp-data/\n'
+              'download_modis --date 20210523 --lons 30 35 --lats 0 10 --satellite aqua --products 06_l2 --fdir_out tmp-data/\n'\
+              'download_modis --date 20130714 --extent 30 35 0 10 --satellite terra --products l1b --fdir_out tmp-data/\n'
 
 
-
+product_options = ['02QKM', '02HKM', '021KM', '06_L2', '03', 'RGB', '43']
 
 class SatelliteDownload:
 
@@ -44,91 +44,112 @@ class SatelliteDownload:
             self,
             date=None,
             extent=None,
-            satellite='aqua',
-            fdir_out='data',
-            product=None,
-            overwrite=False,
-            quiet=False,
+            satellite=None,
+            lons=None,
+            lats=None,
+            fdir_out=None,
+            products=None,
             verbose=False):
 
-        self.date      = date
-        self.extent    = extent
-        self.satellite = satellite
+        # Error handling
+        if satellite.lower() not in ['aqua', 'terra']:
+            msg = '\nError [satellite_download]: Satellite must be either \'Aqua\' or \'Terra\'. %s is currently not supported\n' % satellite
+            sys.exit(msg)
+
+        if len(products) == 0:
+            sys.exit('\nError [download_modis]: Please specify a product to download. We currently support %s\n' % product_options)
+
+        if (extent is None) and ((lats is None) or (lons is None)):
+            sys.exit('\nError [download_modis]: Must provide either extent or lon/lat coordinates\n')
+        elif (extent is None) and ((len(lats) == 2) and (len(lons) == 2)) and (lons[0] < lons[1]) and (lats[0] < lats[1]):
+            self.extent = [lons[0], lons[1], alats[0], lats[1]]
+        elif (len(extent) == 4) and ((lats is None) and (lons is None)):
+            self.extent = extent
+        else:
+            sys.exit('\nError [download_modis]: The provided lon/lat coordinates are incorrect, check again\n')
+
+        if (extent[0] >= extent[1]) or (extent[2] >= extent[3]):
+            msg = '\nError [download_modis]: The given extents of lon/lat are incorrect: %s.\nPlease check to make sure extent is passed as `lon1 lon2 lat1 lat2` format i.e. West, East, South, North.\n' % self.extent
+            sys.exit(msg)
+
+        if not os.path.exists(fdir_out):
+            os.makedirs(fdir_out)
+            if verbose:
+                print('\nMessage [download_modis]: Created %s. Files will be downloaded to this directory\n' % fdir_out)
+
+        self.date = datetime.datetime(int(date[:4]), int(date[4:6]), int(date[6:8]))
+        self.satellite = satellite.lower()
+        self.products  = products
         self.fdir_out  = fdir_out
-        self.quiet     = quiet
         self.verbose   = verbose
 
-
-        elif (((date is not None) and (extent is not None)) and ((overwrite)) or \
-             (((date is not None) and (extent is not None)) and (not os.path.exists(fname))):
-
-            self.run()
-            self.dump(self.fnames)
-
-        elif ((date is not None) and (extent is not None)):
-
-            self.run()
-
-        else:
-
-            sys.exit('Error [satellite_download]: Please  provide \'date\' and \'extent\' to proceed.')
+        self.run()
 
 
-    def run(self, run=True):
+    def run(self):
 
-        if (self.extent[0] >= self.extent[1]) or (self.extent[2] >= self.extent[3]):
-            msg = 'Message [download_modis]: The given extents of lon/lat are incorrect: %s.\nPlease check to make sure extent is passed as `lon1 lon2 lat1 lat2` format i.e West, East, South, North'. % self.extent
-            sys.exit(msg)
         lon0 = np.linspace(self.extent[0], self.extent[1], 100)
         lat0 = np.linspace(self.extent[2], self.extent[3], 100)
         lon, lat = np.meshgrid(lon0, lat0, indexing='ij')
 
         # create prefixes for the satellite products
-        if self.satellite.lower() == 'aqua':
-            dataset_tags = ['61/MYD03', '61/MYD06_L2', '61/MYD02QKM']
-        elif self.satellite.lower() == 'terra':
-            dataset_tags = ['61/MOD03', '61/MOD06_L2', '61/MOD02QKM']
-        else:
-            msg = 'Message [satellite_download]: Satellite must be either \'Aqua\' or \'Terra\'. %s is currently not supported' % self.satellite
-            sys.exit(msg)
+        if self.satellite == 'aqua':
+            sat_prefix = 'MYD'
+            # dataset_tags = ['61/MYD03', '61/MYD06_L2', '61/MYD02QKM']
+        elif self.satellite == 'terra':
+            sat_prefix = 'MOD'
+            # dataset_tags = ['61/MOD03', '61/MOD06_L2', '61/MOD02QKM']
 
-        self.fnames = {}
-
-        # MODIS RGB imagery
-        self.fnames['mod_rgb'] = [download_worldview_rgb(self.date, self.extent, fdir_out=self.fdir_out, satellite=self.satellite, instrument='modis', coastline=True)]
-
-        # MODIS Level 2 Cloud Product and MODIS 03 geo file
-        self.fnames['mod_l2'] = []
-        self.fnames['mod_02'] = []
-        self.fnames['mod_03'] = []
-
-        filename_tags_03 = get_satfile_tag(self.date, lon, lat, satellite=self.satellite, instrument='modis')
+        filename_tags_03 = er3t.util.get_satfile_tag(self.date, lon, lat, satellite=self.satellite, instrument='modis')
         if self.verbose:
-           print('Message [satellite_download]: Found %s %s overpasses' % (len(filename_tags_03), self.satellite))
+           print('\nMessage [satellite_download]: Found %s %s overpasses\n' % (len(filename_tags_03), self.satellite.capitalize()))
 
-        for filename_tag in filename_tags_03:
-            fnames_03     = download_laads_https(self.date, dataset_tags[0], filename_tag, day_interval=1, fdir_out=self.fdir_out, run=run)
-            fnames_l2     = download_laads_https(self.date, dataset_tags[1], filename_tag, day_interval=1, fdir_out=self.fdir_out, run=run)
-            fnames_02     = download_laads_https(self.date, dataset_tags[2], filename_tag, day_interval=1, fdir_out=self.fdir_out, run=run)
+        # add product IDs
+        self.fnames = {}
+        for product in self.products:
+            if product.upper() not in product_options:
+                sys.exit('\nMessage [download_modis]: Specified product %s cannot be downloaded. Currently supported products are \n%s\n' % (product, product_options))
 
-            self.fnames['mod_l2'] += fnames_l2
-            self.fnames['mod_02'] += fnames_02
-            self.fnames['mod_03'] += fnames_03
+            # MODIS RGB imagery
+            if product.upper() == 'RGB':
+                self.fnames['mod_rgb'] = []
+                fnames = [er3t.util.download_worldview_rgb(self.date, self.extent, fdir_out=self.fdir_out, satellite=self.satellite, instrument='modis', coastline=True)]
+                self.fnames['mod_rgb'] += fnames
 
-        # MODIS surface product
-        self.fnames['mod_43'] = []
-        filename_tags_43 = er3t.util.get_sinusoidal_grid_tag(lon, lat)
-        for filename_tag in filename_tags_43:
-            fnames_43 = er3t.util.download_laads_https(self.date, '61/MCD43A3', filename_tag, day_interval=1, fdir_out=self.fdir_out, run=run)
-            self.fnames['mod_43'] += fnames_43
+            # MODIS surface product
+            if product.upper() == '43':
+                self.fnames['mod_43'] = []
+                filename_tags_43 = er3t.util.get_sinusoidal_grid_tag(lon, lat)
+                for filename_tag in filename_tags_43:
+                    fnames = er3t.util.download_laads_https(self.date, '61/MCD43A3', filename_tag, day_interval=1, fdir_out=self.fdir_out)
+                    self.fnames['mod_43'] += fnames
 
-    def dump(self, fname):
+            # MODIS Level-2 cloud products
+            if product.upper() == '06_L2':
+                dataset_tag = '61/' + sat_prefix + product.upper()
+                self.fnames['mod_l2'] = []
+                for filename_tag in filename_tags_03:
+                    fnames = er3t.util.download_laads_https(self.date, dataset_tag, filename_tag, day_interval=1, fdir_out=self.fdir_out)
+                    self.fnames['mod_l2'] += fnames
 
-        self.fname = fname
-        with open(fname, 'wb') as f:
-            if self.verbose:
-                print('Message [satellite_download]: Saving object into %s ...' % fname)
-            pickle.dump(self, f)
+            # MODIS Level-1b radiances
+            if product.upper() in ['02QKM', '02HKM', '021KM']:
+                dataset_tag = '61/' + sat_prefix + product.upper()
+                self.fnames['mod_l2'] = []
+                for filename_tag in filename_tags_03:
+                    fnames = er3t.util.download_laads_https(self.date, dataset_tag, filename_tag, day_interval=1, fdir_out=self.fdir_out)
+                    self.fnames['mod_l2'] += fnames
+
+            # MODIS solar/viewing geometries product
+            if product.upper() == '03':
+                dataset_tag = '61/' + sat_prefix + product.upper()
+                self.fnames['mod_l2'] = []
+                for filename_tag in filename_tags_03:
+                    fnames = er3t.util.download_laads_https(self.date, dataset_tag, filename_tag, day_interval=1, fdir_out=self.fdir_out)
+                    self.fnames['mod_l2'] += fnames
+
+        print('\nMessage [download_modis]: Finished downloading MODIS files! You can find them in %s\n' % self.fdir_out)
+
 
 if __name__ == '__main__':
 
@@ -137,27 +158,64 @@ if __name__ == '__main__':
     parser.add_argument('-f', '--fdir', type=str, metavar='', default='modis-data/',
                         help='Directory where the files will be downloaded\n'\
                              'By default, files will be downloaded to \'modis-data/\'')
+    parser.add_argument('-v', '--verbose', action='store_true',
+                        help='Pass --verbose if status of your request should be reported frequently.\n'\
+                             'This is disabled by default.')
+    parser.add_argument('-r', '--run_demo', action='store_true',
+                        help='Pass --run_demo if you would like to run a demonstration of this tool.')
     required = parser.add_argument_group('Required Arguments')
-    required.add_argument('-d', '--date', type=int, required=True, metavar='',
+    required.add_argument('-d', '--date', type=str, metavar='',
                         help='Date for which you would like to download data. '\
                         'Use yyyymmdd format.\nExample: --date 20210404')
-    required.add_argument('-e', '--extent', nargs='+', type=float, required=True, metavar='',
+    required.add_argument('-e', '--extent', nargs='+', type=float, metavar='',
                         help='Extent of region of interest lon1 lon2 lat1 lat2 in West East South North format.\n'\
                                 'Example:  --extent -10 -5 25 30')
+    required.add_argument('-x', '--lons', nargs='+', type=float, metavar='',
+                        help='The west-most and east-most longitudes of the region. Alternative to providing the first two terms in `extent`.\n'\
+                                'Example:  --lons -10 -5')
+    required.add_argument('-y', '--lats', nargs='+', type=float, metavar='',
+                        help='The south-most and north-most latitudes of the region. Alternative to providing the last two terms in `extent`.\n'\
+                                'Example:  --lats 25 30')
     required.add_argument('-s','--satellite', type=str, metavar='',
                         help='One of \'Aqua\' or \'Terra\'. Case insensitive. \n'\
                              'Example: --satellite terra')
-    required.add_argument('-p', '--product', type=str, nargs='+', required=True, metavar='',
+    required.add_argument('-p', '--products', type=str, nargs='+', metavar='',
                         help='Short prefix (case insensitive) for the product name. Currently supported products are:\n'\
                         '02QKM: Level 1b 250m radiance product\n'\
                         '02HKM: Level 1b 500m radiance product\n'\
                         '021KM: Level 1b 1km radiance product\n'\
                         '03:    Solar/viewing geometry product\n'\
                         '06_L2: Level 2 cloud product\n'\
+                        '43:    Level 2 surface product MCD43A3\n'\
                         'RGB:   False-color RGB imagery, useful for visuzliation'
                         '\nTo download multiple products at a time:\n'\
                         '--product 021km 02hkm 06_l2\n')
 
     args = parser.parse_args()
 
-    print(args.product)
+    if args.run_demo:
+        date      = '20210714'
+        extent    = [-79.4, -71.1, 21.6, 25.8]
+        lons      = None
+        lats      = None
+        satellite = 'aqua'
+        fdir      = 'tmp-data/'
+        products  = ['RGB', '02QKM']
+        verbose   = 1
+        sat0 = SatelliteDownload(date=date,
+                                 extent=extent,
+                                 lons=lons,
+                                 lats=lats,
+                                 satellite=satellite,
+                                 fdir_out=fdir,
+                                 products=products,
+                                 verbose=verbose)
+    else:
+        sat0 = SatelliteDownload(date=args.date,
+                                extent=args.extent,
+                                lons=args.lons,
+                                lats=args.lats,
+                                satellite=args.satellite,
+                                fdir_out=args.fdir,
+                                products=args.products,
+                                verbose=args.verbose)

--- a/bin/download_modis
+++ b/bin/download_modis
@@ -12,6 +12,9 @@ Authors:
 Example Usage:
     download_modis --date 20210523 --lons 30 35 --lats 0 10 --satellite aqua --products 06_l2 --fdir tmp-data/
     download_modis --date 20130714 --extent 30 35 0 10 --satellite terra --products rgb 02hkm 06_l2 --fdir tmp-data/
+
+To see a demonstration of how this tool works, use:
+    download_modis --run_demo
 """
 
 import os

--- a/bin/download_modis
+++ b/bin/download_modis
@@ -37,6 +37,10 @@ description = '=================================================================
 
 
 product_options = ['02QKM', '02HKM', '021KM', '06_L2', '03', 'RGB', '43']
+product_names   = ['MODIS Level 1b Radiances (250 m)', 'MODIS Level 1b Radiances (500 m)', 'MODIS Level 1b Radiances (1 km)',
+                   'MODIS Level 2 Cloud Product', 'MODIS Solar/Viewing Geometries', 'MODIS False-Color RGB Imagery',
+                   'MODIS Level 2 Surface Reflectance/Albedo Product']
+product_dict    = dict(zip(product_options, product_names))
 
 class SatelliteDownload:
 
@@ -62,7 +66,7 @@ class SatelliteDownload:
         if (extent is None) and ((lats is None) or (lons is None)):
             sys.exit('\nError [download_modis]: Must provide either extent or lon/lat coordinates\n')
         elif (extent is None) and ((len(lats) == 2) and (len(lons) == 2)) and (lons[0] < lons[1]) and (lats[0] < lats[1]):
-            self.extent = [lons[0], lons[1], alats[0], lats[1]]
+            self.extent = [lons[0], lons[1], lats[0], lats[1]]
         elif (len(extent) == 4) and ((lats is None) and (lons is None)):
             self.extent = extent
         else:
@@ -102,13 +106,18 @@ class SatelliteDownload:
 
         filename_tags_03 = er3t.util.get_satfile_tag(self.date, lon, lat, satellite=self.satellite, instrument='modis')
         if self.verbose:
-           print('\nMessage [satellite_download]: Found %s %s overpasses\n' % (len(filename_tags_03), self.satellite.capitalize()))
+            print('===================================================================\n\n'\
+                 '\nMessage [satellite_download]: Found %s %s overpasses\n' % (len(filename_tags_03), self.satellite.capitalize()))
 
         # add product IDs
         self.fnames = {}
         for product in self.products:
             if product.upper() not in product_options:
                 sys.exit('\nMessage [download_modis]: Specified product %s cannot be downloaded. Currently supported products are \n%s\n' % (product, product_options))
+
+            if self.verbose:
+                print('===================================================================\n\n'\
+                      '               %s                 \n'% product_dict[product.upper()])
 
             # MODIS RGB imagery
             if product.upper() == 'RGB':
@@ -121,7 +130,7 @@ class SatelliteDownload:
                 self.fnames['mod_43'] = []
                 filename_tags_43 = er3t.util.get_sinusoidal_grid_tag(lon, lat)
                 for filename_tag in filename_tags_43:
-                    fnames = er3t.util.download_laads_https(self.date, '61/MCD43A3', filename_tag, day_interval=1, fdir_out=self.fdir_out)
+                    fnames = er3t.util.download_laads_https(self.date, '61/MCD43A3', filename_tag, day_interval=1, fdir_out=self.fdir_out, verbose=self.verbose)
                     self.fnames['mod_43'] += fnames
 
             # MODIS Level-2 cloud products
@@ -129,7 +138,7 @@ class SatelliteDownload:
                 dataset_tag = '61/' + sat_prefix + product.upper()
                 self.fnames['mod_l2'] = []
                 for filename_tag in filename_tags_03:
-                    fnames = er3t.util.download_laads_https(self.date, dataset_tag, filename_tag, day_interval=1, fdir_out=self.fdir_out)
+                    fnames = er3t.util.download_laads_https(self.date, dataset_tag, filename_tag, day_interval=1, fdir_out=self.fdir_out, verbose=self.verbose)
                     self.fnames['mod_l2'] += fnames
 
             # MODIS Level-1b radiances
@@ -137,7 +146,7 @@ class SatelliteDownload:
                 dataset_tag = '61/' + sat_prefix + product.upper()
                 self.fnames['mod_l2'] = []
                 for filename_tag in filename_tags_03:
-                    fnames = er3t.util.download_laads_https(self.date, dataset_tag, filename_tag, day_interval=1, fdir_out=self.fdir_out)
+                    fnames = er3t.util.download_laads_https(self.date, dataset_tag, filename_tag, day_interval=1, fdir_out=self.fdir_out, verbose=self.verbose)
                     self.fnames['mod_l2'] += fnames
 
             # MODIS solar/viewing geometries product
@@ -145,7 +154,7 @@ class SatelliteDownload:
                 dataset_tag = '61/' + sat_prefix + product.upper()
                 self.fnames['mod_l2'] = []
                 for filename_tag in filename_tags_03:
-                    fnames = er3t.util.download_laads_https(self.date, dataset_tag, filename_tag, day_interval=1, fdir_out=self.fdir_out)
+                    fnames = er3t.util.download_laads_https(self.date, dataset_tag, filename_tag, day_interval=1, fdir_out=self.fdir_out, verbose=self.verbose)
                     self.fnames['mod_l2'] += fnames
 
         print('\nMessage [download_modis]: Finished downloading MODIS files! You can find them in %s\n' % self.fdir_out)
@@ -202,6 +211,7 @@ if __name__ == '__main__':
         fdir      = 'tmp-data/'
         products  = ['RGB', '02QKM']
         verbose   = 1
+
         sat0 = SatelliteDownload(date=date,
                                  extent=extent,
                                  lons=lons,

--- a/bin/download_modis
+++ b/bin/download_modis
@@ -1,0 +1,163 @@
+#!/usr/bin/env python
+
+"""
+Downloads MODIS products given location (lat/lon) and date.
+
+This is a functionality of EaR3T.
+
+Authors:
+    Original code written by Hong Chen.
+    Modified by Vikas Nataraja.
+
+Example Usage:
+    download_modis --date 20210523 --lon 30 --lat 0 --satellite aqua --product mod06_l2 --fdir_out tmp-data/
+    download_modis --date 20130714 --extent 30 35 0 10 --satellite terra --product modl1b --fdir_out tmp-data/
+"""
+
+import os
+import sys
+import pickle
+import h5py
+from pyhdf.SD import SD, SDC
+from argparse import ArgumentParser, RawTextHelpFormatter,  RawDescriptionHelpFormatter
+import numpy as np
+import datetime
+
+
+import er3t
+
+# set welcome text
+description = '===================================================================\n\n'\
+              '    Education and Research 3D Radiative Transfer Toolbox (EaR\u00b3T)  \n\n'\
+              '===================================================================\n'\
+              '================ MODIS Data Product Download Tool =================\n'\
+              'Example Usage:\n'\
+              'download_modis --date 20210523 --lon 30 35 --lat 0 10 --satellite aqua --product mod06_l2 --fdir_out tmp-data/\n'\
+              'download_modis --date 20130714 --extent 30 35 0 10 --satellite terra --product modl1b --fdir_out tmp-data/\n'
+
+
+
+
+class SatelliteDownload:
+
+    def __init__(
+            self,
+            date=None,
+            extent=None,
+            satellite='aqua',
+            fdir_out='data',
+            product=None,
+            overwrite=False,
+            quiet=False,
+            verbose=False):
+
+        self.date      = date
+        self.extent    = extent
+        self.satellite = satellite
+        self.fdir_out  = fdir_out
+        self.quiet     = quiet
+        self.verbose   = verbose
+
+
+        elif (((date is not None) and (extent is not None)) and ((overwrite)) or \
+             (((date is not None) and (extent is not None)) and (not os.path.exists(fname))):
+
+            self.run()
+            self.dump(self.fnames)
+
+        elif ((date is not None) and (extent is not None)):
+
+            self.run()
+
+        else:
+
+            sys.exit('Error [satellite_download]: Please  provide \'date\' and \'extent\' to proceed.')
+
+
+    def run(self, run=True):
+
+        if (self.extent[0] >= self.extent[1]) or (self.extent[2] >= self.extent[3]):
+            msg = 'Message [download_modis]: The given extents of lon/lat are incorrect: %s.\nPlease check to make sure extent is passed as `lon1 lon2 lat1 lat2` format i.e West, East, South, North'. % self.extent
+            sys.exit(msg)
+        lon0 = np.linspace(self.extent[0], self.extent[1], 100)
+        lat0 = np.linspace(self.extent[2], self.extent[3], 100)
+        lon, lat = np.meshgrid(lon0, lat0, indexing='ij')
+
+        # create prefixes for the satellite products
+        if self.satellite.lower() == 'aqua':
+            dataset_tags = ['61/MYD03', '61/MYD06_L2', '61/MYD02QKM']
+        elif self.satellite.lower() == 'terra':
+            dataset_tags = ['61/MOD03', '61/MOD06_L2', '61/MOD02QKM']
+        else:
+            msg = 'Message [satellite_download]: Satellite must be either \'Aqua\' or \'Terra\'. %s is currently not supported' % self.satellite
+            sys.exit(msg)
+
+        self.fnames = {}
+
+        # MODIS RGB imagery
+        self.fnames['mod_rgb'] = [download_worldview_rgb(self.date, self.extent, fdir_out=self.fdir_out, satellite=self.satellite, instrument='modis', coastline=True)]
+
+        # MODIS Level 2 Cloud Product and MODIS 03 geo file
+        self.fnames['mod_l2'] = []
+        self.fnames['mod_02'] = []
+        self.fnames['mod_03'] = []
+
+        filename_tags_03 = get_satfile_tag(self.date, lon, lat, satellite=self.satellite, instrument='modis')
+        if self.verbose:
+           print('Message [satellite_download]: Found %s %s overpasses' % (len(filename_tags_03), self.satellite))
+
+        for filename_tag in filename_tags_03:
+            fnames_03     = download_laads_https(self.date, dataset_tags[0], filename_tag, day_interval=1, fdir_out=self.fdir_out, run=run)
+            fnames_l2     = download_laads_https(self.date, dataset_tags[1], filename_tag, day_interval=1, fdir_out=self.fdir_out, run=run)
+            fnames_02     = download_laads_https(self.date, dataset_tags[2], filename_tag, day_interval=1, fdir_out=self.fdir_out, run=run)
+
+            self.fnames['mod_l2'] += fnames_l2
+            self.fnames['mod_02'] += fnames_02
+            self.fnames['mod_03'] += fnames_03
+
+        # MODIS surface product
+        self.fnames['mod_43'] = []
+        filename_tags_43 = er3t.util.get_sinusoidal_grid_tag(lon, lat)
+        for filename_tag in filename_tags_43:
+            fnames_43 = er3t.util.download_laads_https(self.date, '61/MCD43A3', filename_tag, day_interval=1, fdir_out=self.fdir_out, run=run)
+            self.fnames['mod_43'] += fnames_43
+
+    def dump(self, fname):
+
+        self.fname = fname
+        with open(fname, 'wb') as f:
+            if self.verbose:
+                print('Message [satellite_download]: Saving object into %s ...' % fname)
+            pickle.dump(self, f)
+
+if __name__ == '__main__':
+
+    parser = ArgumentParser(prog='download_modis', formatter_class=RawTextHelpFormatter,
+                            description=description, usage='%(prog)s [-h] [--help] [-i]')
+    parser.add_argument('-f', '--fdir', type=str, metavar='', default='modis-data/',
+                        help='Directory where the files will be downloaded\n'\
+                             'By default, files will be downloaded to \'modis-data/\'')
+    required = parser.add_argument_group('Required Arguments')
+    required.add_argument('-d', '--date', type=int, required=True, metavar='',
+                        help='Date for which you would like to download data. '\
+                        'Use yyyymmdd format.\nExample: --date 20210404')
+    required.add_argument('-e', '--extent', nargs='+', type=float, required=True, metavar='',
+                        help='Extent of region of interest lon1 lon2 lat1 lat2 in West East South North format.\n'\
+                                'Example:  --extent -10 -5 25 30')
+    required.add_argument('-s','--satellite', type=str, metavar='',
+                        help='One of \'Aqua\' or \'Terra\'. Case insensitive. \n'\
+                             'Example: --satellite terra')
+    required.add_argument('-p', '--product', type=str, nargs='+', required=True, metavar='',
+                        help='Short prefix (case insensitive) for the product name. Currently supported products are:\n'\
+                        '02QKM: Level 1b 250m radiance product\n'\
+                        '02HKM: Level 1b 500m radiance product\n'\
+                        '021KM: Level 1b 1km radiance product\n'\
+                        '03:    Solar/viewing geometry product\n'\
+                        '06_L2: Level 2 cloud product\n'\
+                        'RGB:   False-color RGB imagery, useful for visuzliation'
+                        '\nTo download multiple products at a time:\n'\
+                        '--product 021km 02hkm 06_l2\n')
+
+    args = parser.parse_args()
+
+    print(args.product)

--- a/er3t/util/util.py
+++ b/er3t/util/util.py
@@ -23,7 +23,7 @@ __all__ = ['all_files', 'check_equal', 'check_equidistant', 'send_email', \
            'nice_array_str', 'h5dset_to_pydict', 'dtime_to_jday', 'jday_to_dtime', \
            'get_data_nc', 'get_data_h4', \
            'grid_by_extent', 'grid_by_lonlat', 'get_doy_tag', \
-           'haversine', 'cal_lonlat_by_dist', 're_extend', 'get_satfile_tag'\
+           'haversine', 'cal_lonlat_by_dist', 're_extend', 'get_satfile_tag',\
            'download_laads_https', 'download_worldview_rgb'] + \
           ['combine_alt', 'get_lay_index', 'downscale', 'upscale_2d', 'mmr2vmr', \
            'cal_rho_air', 'cal_sol_fac', 'cal_mol_ext', 'cal_ext', \
@@ -547,7 +547,7 @@ def haversine(lon1, lon2, lat1, lat2):
 # sphere with this radius results in an error of up to about 0.5%.
 EARTH_RADIUS = 6371.009
 
-def calc_lonlat_by_dist(lon1, lat1, bearing, distance):
+def cal_lonlat_by_dist(lon1, lat1, bearing, distance):
     """
     Gets lat/lon of the destination point given an initial point,
     bearing, and the great circle distance between the points.

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
          'owslib',
          'cartopy'],
      python_requires = '~=3.9',
-     scripts = ['bin/lss', 'bin/lsa'],
+     scripts = ['bin/lss', 'bin/lsa', 'bin/download_modis'],
      include_package_data = True,
      zip_safe = False
      )


### PR DESCRIPTION
This PR is to enable a command line functionality for downloading MODIS files (https://github.com/hong-chen/er3t/issues/6). To test, do the following after fetching and pulling from `dev_vikas`:
```
python3 setup.py develop

download_modis --run_demo
```

Other commands like these can also be tried:
 ```
download_modis --date 20210523 --lons 30 35 --lats 0 10 --satellite aqua --products 06_l2 --fdir tmp-data/

download_modis --date 20130714 --extent 30 35 0 10 --satellite terra --products rgb 02hkm 06_l2 --fdir tmp-data/
```

To view a full list of its capabilities and arguments, use `download_modis --help`.