### PR TITLE
Improvements for MODIS `L1b` and `35_L2` readers

### DIFF
--- a/bin/sdown
+++ b/bin/sdown
@@ -220,111 +220,99 @@ _sat_tags_support_ = {
 #\----------------------------------------------------------------------------/#
 
 
-class SatelliteDownload:
+def satellite_download(date, extent, lons, lats, fdir_out, products, verbose):
 
-    def __init__(
-            self,
-            date=None,
-            extent=None,
-            lons=None,
-            lats=None,
-            fdir_out=None,
-            products=None,
-            verbose=False):
 
-        # Error handling
-        if len(products) == 0:
-            sys.exit('\nError [sdown]: Please specify a product to download. We currently support %s\n' % product_options)
+    # Error handling
+    if products is None:
+        sys.exit('\nError [sdown]: Please specify a product to download. \nWe currently support the following:\n%s\n' % ('\n'.join(_sat_tags_support_.keys())))
 
-        if (extent is None) and ((lats is None) or (lons is None)):
-            sys.exit('\nError [sdown]: Must provide either extent or lon/lat coordinates\n')
-        elif (extent is None) and ((len(lats) == 2) and (len(lons) == 2)) and (lons[0] < lons[1]) and (lats[0] < lats[1]):
-            self.extent = [lons[0], lons[1], lats[0], lats[1]]
-        elif (len(extent) == 4) and ((lats is None) and (lons is None)):
-            self.extent = extent
-        else:
-            sys.exit('\nError [sdown]: The provided lon/lat coordinates are incorrect, check again\n')
+    if (extent is None) and ((lats is None) or (lons is None)):
+        sys.exit('\nError [sdown]: Must provide either extent or lon/lat coordinates\n')
 
-        if (self.extent[0] >= self.extent[1]) or (self.extent[2] >= self.extent[3]):
-            msg = '\nError [sdown]: The given extents of lon/lat are incorrect: %s.\nPlease check to make sure extent is passed as `lon1 lon2 lat1 lat2` format i.e. West, East, South, North.\n' % self.extent
-            sys.exit(msg)
+    elif (extent is not None) and (len(extent) != 4) and ((lats is None) or (lons is None) or (len(lats) == 0) or (len(lons) == 0)):
+        sys.exit('\nError [sdown]: Must provide either extent with [lon1 lon2 lat1 lat2] or lon/lat coordinates via --lon and --lat\n')
 
-        if not os.path.exists(fdir_out):
-            os.makedirs(fdir_out)
+    elif (extent is None) and (lats is not None) and (lons is not None) and ((len(lats) == 2) and (len(lons) == 2)) and (lons[0] < lons[1]) and (lats[0] < lats[1]):
+        extent = [lons[0], lons[1], lats[0], lats[1]]
+
+
+    if (extent[0] >= extent[1]) or (extent[2] >= extent[3]):
+        msg = '\nError [sdown]: The given extents of lon/lat are incorrect: %s.\nPlease check to make sure extent is passed as `lon1 lon2 lat1 lat2` format i.e. West, East, South, North.\n' % extent
+        sys.exit(msg)
+
+    if not os.path.exists(fdir_out):
+        os.makedirs(fdir_out)
+        if verbose:
+            print('\nMessage [sdown]: Created %s. Files will be downloaded to this directory\n' % fdir_out)
+
+    date = datetime.datetime(int(date[:4]), int(date[4:6]), int(date[6:8]))
+
+    run(date, extent, fdir_out, products, verbose)
+
+
+def run(date, extent, fdir_out, products, verbose):
+
+    lon0 = np.linspace(extent[0], extent[1], 100)
+    lat0 = np.linspace(extent[2], extent[3], 100)
+    lon, lat = np.meshgrid(lon0, lat0, indexing='ij')
+
+    # add product IDs
+    fnames = {}
+    for product in products:
+
+        product_info = get_sat_info_from_product_tag(product)
+        fnames[product_info['dict_key']] = []
+        if verbose:
+            stdout = '=' * _width_ + '\n\n%s\n' % product_info['description'].center(_width_)
+            print(stdout)
+
+        # MODIS RGB imagery
+        if 'RGB' in product.upper():
+            p_fnames = [er3t.util.download_worldview_rgb(date=date,
+                                                         extent=extent,
+                                                         fdir_out=fdir_out,
+                                                         satellite=product_info['satellite'],
+                                                         instrument=product_info['instrument'],
+                                                         coastline=False)]
+            fnames[product_info['dict_key']] += p_fnames
+
+        # MODIS surface product
+        elif '43' in product.upper():
+            filename_tags_43 = er3t.util.get_sinusoidal_grid_tag(lon, lat)
+            for filename_tag in filename_tags_43:
+                p_fnames = er3t.util.download_laads_https(date=date,
+                                                        dataset_tag=product_info['dataset_tag'],
+                                                        filename_tag=filename_tag,
+                                                        day_interval=1,
+                                                        fdir_out=fdir_out,
+                                                        verbose=verbose)
+                fnames[product_info['dict_key']] += p_fnames
+
+        # MODIS Level-1b radiances, Level-2 cloud products, and solar/viewing geoemetries
+        elif product.upper().endswith(('QKM', 'HKM', '1KM', '06_L2', '03')):
+            filename_tags_03 = er3t.util.get_satfile_tag(date=date,
+                                                         lon=lon,
+                                                         lat=lat,
+                                                         satellite=product_info['satellite'],
+                                                         instrument=product_info['instrument'],
+                                                         verbose=verbose)
             if verbose:
-                print('\nMessage [sdown]: Created %s. Files will be downloaded to this directory\n' % fdir_out)
+                print('Message [sdown]: Found %s %s overpasses\n' % (len(filename_tags_03), product_info['satellite']))
 
-        self.date = datetime.datetime(int(date[:4]), int(date[4:6]), int(date[6:8]))
-        self.products  = products
-        self.fdir_out  = fdir_out
-        self.verbose   = verbose
+            for filename_tag in filename_tags_03:
+                p_fnames = er3t.util.download_laads_https(date=date,
+                                                        dataset_tag=product_info['dataset_tag'],
+                                                        filename_tag=filename_tag,
+                                                        day_interval=1,
+                                                        fdir_out=fdir_out,
+                                                        verbose=verbose)
+                fnames[product_info['dict_key']] += p_fnames
 
-        self.run()
-
-
-    def run(self):
-
-        lon0 = np.linspace(self.extent[0], self.extent[1], 100)
-        lat0 = np.linspace(self.extent[2], self.extent[3], 100)
-        lon, lat = np.meshgrid(lon0, lat0, indexing='ij')
-
-
-        # add product IDs
-        self.fnames = {}
-        for product in self.products:
-
-            product_info = get_sat_info_from_product_tag(product)
-            self.fnames[product_info['dict_key']] = []
-            if self.verbose:
-                stdout = '=' * _width_ + '\n\n%s\n' % product_info['description'].center(_width_)
-                print(stdout)
-
-            # MODIS RGB imagery
-            if 'RGB' in product.upper():
-                fnames = [er3t.util.download_worldview_rgb(date=self.date,
-                                                           extent=self.extent,
-                                                           fdir_out=self.fdir_out,
-                                                           satellite=product_info['satellite'],
-                                                           instrument=product_info['instrument'],
-                                                           coastline=True)]
-                self.fnames[product_info['dict_key']] += fnames
-
-            # MODIS surface product
-            elif '43' in product.upper():
-                filename_tags_43 = er3t.util.get_sinusoidal_grid_tag(lon, lat)
-                for filename_tag in filename_tags_43:
-                    fnames = er3t.util.download_laads_https(date=self.date,
-                                                            dataset_tag=product_info['dataset_tag'],
-                                                            filename_tag=filename_tag,
-                                                            day_interval=1,
-                                                            fdir_out=self.fdir_out,
-                                                            verbose=self.verbose)
-                    self.fnames[product_info['dict_key']] += fnames
-
-            # MODIS Level-1b radiances, Level-2 cloud products, and solar/viewing geoemetries
-            elif product.upper().endswith(('QKM', 'HKM', '1KM', '06_L2', '03')):
-                filename_tags_03 = er3t.util.get_satfile_tag(date=self.date,
-                                                             lon=lon,
-                                                             lat=lat,
-                                                             satellite=product_info['satellite'],
-                                                             instrument=product_info['instrument'],
-                                                             verbose=self.verbose)
-                if self.verbose:
-                    print('Message [sdown]: Found %s %s overpasses\n' % (len(filename_tags_03), product_info['satellite']))
-
-                for filename_tag in filename_tags_03:
-                    fnames = er3t.util.download_laads_https(date=self.date,
-                                                            dataset_tag=product_info['dataset_tag'],
-                                                            filename_tag=filename_tag,
-                                                            day_interval=1,
-                                                            fdir_out=self.fdir_out,
-                                                            verbose=self.verbose)
-                    self.fnames[product_info['dict_key']] += fnames
-
-            else:
-                msg = '\nError [sdown]: Cannot recognize satellite product from the given tag <%s>, abort...\nCurrently, only the following satellite products are supported by <sdown>:\n%s' % (product, '\n'.join(_sat_tags_support_.keys()))
-                raise OSError(msg)
-        print('\nMessage [sdown]: Finished downloading MODIS files! You can find them in %s\n' % self.fdir_out)
+        else:
+            msg = '\nError [sdown]: Cannot recognize satellite product from the given tag <%s>, abort...\nCurrently, only the following satellite products are supported by <sdown>:\n%s' % (product, '\n'.join(_sat_tags_support_.keys()))
+            raise OSError(msg)
+    print('\nMessage [sdown]: Finished downloading MODIS files! You can find them in %s\n' % fdir_out)
 
 
 def get_sat_info_from_product_tag(tag_):
@@ -405,18 +393,18 @@ if __name__ == '__main__':
         products  = ['MODRGB', 'MYD02QKM']
         verbose   = 1
 
-        sat0 = SatelliteDownload(date=date,
-                                 extent=extent,
-                                 lons=lons,
-                                 lats=lats,
-                                 fdir_out=fdir,
-                                 products=products,
-                                 verbose=verbose)
+        sat0 = satellite_download(date=date,
+                                  extent=extent,
+                                  lons=lons,
+                                  lats=lats,
+                                  fdir_out=fdir,
+                                  products=products,
+                                  verbose=verbose)
     else:
-        sat0 = SatelliteDownload(date=args.date,
-                                extent=args.extent,
-                                lons=args.lons,
-                                lats=args.lats,
-                                fdir_out=args.fdir,
-                                products=args.products,
-                                verbose=args.verbose)
+        sat0 = satellite_download(date=args.date,
+                                  extent=args.extent,
+                                  lons=args.lons,
+                                  lats=args.lats,
+                                  fdir_out=args.fdir,
+                                  products=args.products,
+                                  verbose=args.verbose)

--- a/bin/sdown
+++ b/bin/sdown
@@ -63,7 +63,7 @@ _sat_tags_support_ = {
                     'website': 'https://worldview.earthdata.nasa.gov',
                   'satellite': 'Terra',
                  'instrument': 'MODIS',
-            'acknowledgement': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
+                  'reference': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
                 },
 
         'MYDRGB': {
@@ -73,7 +73,7 @@ _sat_tags_support_ = {
                     'website': 'https://worldview.earthdata.nasa.gov',
                   'satellite': 'Aqua',
                  'instrument': 'MODIS',
-            'acknowledgement': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
+                  'reference': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
                 },
 
         'MOD03': {
@@ -176,6 +176,26 @@ _sat_tags_support_ = {
                   'reference': 'Platnick, S., Ackerman, S. A., King, M. D. , Meyer, K., Menzel, W. P. , Holz, R. E., Baum, B. A., and Yang, P., 2015: MODIS atmosphere L2 cloud product (06_L2), NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD06_L2.061 (last access: %s), 2015.' % _date_today_,
                 },
 
+        'MOD35_L2': {
+                'dataset_tag': '61/MOD35_L2',
+                   'dict_key': 'mod_l2',
+                'description': 'Terra MODIS Atmosphere L2 Cloud Mask',
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MOD35_L2.061',
+                  'satellite': 'Terra',
+                 'instrument': 'MODIS',
+                  'reference': 'Ackerman, S., P. Menzel, R. Frey, B.Baum, 2017. MODIS Atmosphere L2 Cloud Mask Product. NASA MODIS Adaptive Processing System, Goddard Space Flight Center, [doi:10.5067/MODIS/MOD35_L2.061'
+                },
+
+        'MYD35_L2': {
+                'dataset_tag': '61/MYD35_L2',
+                   'dict_key': 'myd_l2',
+                'description': 'Aqua MODIS Atmosphere L2 Cloud Mask',
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MYD35_L2.061',
+                  'satellite': 'Aqua',
+                 'instrument': 'MODIS',
+                  'reference': 'Ackerman, S., P. Menzel, R. Frey, B.Baum, 2017. MODIS Atmosphere L2 Cloud Mask Product. NASA MODIS Adaptive Processing System, Goddard Space Flight Center, [doi:10.5067/MODIS/MYD35_L2.061]'
+                },
+
         'MCD43A3': {
                 'dataset_tag': '61/MCD43A3',
                    'dict_key': 'mod_43',
@@ -257,12 +277,13 @@ def run(date, extent, fdir_out, products, verbose):
     lat0 = np.linspace(extent[2], extent[3], 100)
     lon, lat = np.meshgrid(lon0, lat0, indexing='ij')
 
-    # add product IDs
+    references = []
     fnames = {}
     for product in products:
 
         product_info = get_sat_info_from_product_tag(product)
         fnames[product_info['dict_key']] = []
+
         if verbose:
             stdout = '=' * _width_ + '\n\n%s\n' % product_info['description'].center(_width_)
             print(stdout)
@@ -290,7 +311,7 @@ def run(date, extent, fdir_out, products, verbose):
                 fnames[product_info['dict_key']] += p_fnames
 
         # MODIS Level-1b radiances, Level-2 cloud products, and solar/viewing geoemetries
-        elif product.upper().endswith(('QKM', 'HKM', '1KM', '06_L2', '03')):
+        elif product.upper().endswith(('QKM', 'HKM', '1KM', 'L2', '03')):
             filename_tags_03 = er3t.util.get_satfile_tag(date=date,
                                                          lon=lon,
                                                          lat=lat,
@@ -312,6 +333,10 @@ def run(date, extent, fdir_out, products, verbose):
         else:
             msg = '\nError [sdown]: Cannot recognize satellite product from the given tag <%s>, abort...\nCurrently, only the following satellite products are supported by <sdown>:\n%s' % (product, '\n'.join(_sat_tags_support_.keys()))
             raise OSError(msg)
+
+        references.append(product_info['reference'])
+    
+    print('Please cite the use of this data as follows:\n%s' % '\n\n'.join(references))
     print('\nMessage [sdown]: Finished downloading MODIS files! You can find them in %s\n' % fdir_out)
 
 

--- a/bin/sdown
+++ b/bin/sdown
@@ -4,8 +4,8 @@
 Downloads satellite data products for any user-specified date and geolocation location (lat/lon).
 
 Now supports:
-    MODIS data: MOD-RGB,  MYD-RGB 
-                MOD03,    MYD03 
+    MODIS data: MOD-RGB,  MYD-RGB
+                MOD03,    MYD03
                 MOD02QKM, MYD02QKM
                 MOD02HKM, MYD02HKM
                 MOD021KM, MYD021KM
@@ -38,190 +38,190 @@ import datetime
 import er3t
 
 # get width for stdout statements
-width = os.get_terminal_size().columns
+_width_ = os.get_terminal_size().columns
 
 # set welcome text
-description = '===================================================================\n\n'\
-              '    Education and Research 3D Radiative Transfer Toolbox (EaR\u00b3T)  \n\n'\
-              '===================================================================\n'\
-              '============== Satellite Data Product Download Tool ===============\n'\
-              'Example Usage:\n'\
-              'sdown --date 20210523 --lons 30 35 --lats 0 10 --satellite aqua --products 06_l2 --fdir_out tmp-data\n'\
-              'sdown --date 20130714 --extent 30 35 0 10 --satellite terra --products l1b --fdir_out tmp-data\n'
+_description_ = '===================================================================\n\n'\
+                '    Education and Research 3D Radiative Transfer Toolbox (EaR\u00b3T)  \n\n'\
+                '===================================================================\n'\
+                '============== Satellite Data Product Download Tool ===============\n'\
+                'Example Usage:\n'\
+                'sdown --date 20210523 --lons 30 35 --lats 0 10 --satellite aqua --products 06_l2 --fdir_out tmp-data\n'\
+                'sdown --date 20130714 --extent 30 35 0 10 --satellite terra --products l1b --fdir_out tmp-data\n'
 
-description = '=' * width + '\n\n' + \
-              'Education and Research 3D Radiative Transfer Toolbox (EaR\u00b3T)'.center(width) + '\n\n' + \
-              '=' * width + '\n' + \
-              ' Satellite Data Product Download Tool '.center(width, '=') + '\n\n' + \
-              'Example Usage:\n'\
-              'sdown --date 20210523 --lons 30 35 --lats 0 10 --satellite aqua --products 06_l2 --fdir_out tmp-data\n'\
-              'sdown --date 20130714 --extent 30 35 0 10 --satellite terra --products l1b --fdir_out tmp-data\n'
+_description_ = '=' * _width_ + '\n\n' + \
+                'Education and Research 3D Radiative Transfer Toolbox (EaR\u00b3T)'.center(_width_) + '\n\n' + \
+                '=' * _width_ + '\n' + \
+                ' Satellite Data Product Download Tool '.center(_width_, '=') + '\n\n' + \
+                'Example Usage:\n'\
+                'sdown --date 20210523 --lons 30 35 --lats 0 10 --satellite aqua --products 06_l2 --fdir_out tmp-data\n'\
+                'sdown --date 20130714 --extent 30 35 0 10 --satellite terra --products l1b --fdir_out tmp-data\n'
 
 # product tags
-# this <tags_support_> will be updated over time
+# this <_sat_tags_support_> will be updated over time
 #/----------------------------------------------------------------------------\#
-date_today_str = datetime.date.today().strftime('%d %B, %Y')
+_date_today_ = datetime.date.today().strftime('%d %B, %Y')
 
-tags_support_ = {
+_sat_tags_support_ = {
 
         'MODRGB': {
                 'dataset_tag': 'MODRGB',
-                'dict_key': 'mod_rgb',
+                   'dict_key': 'mod_rgb',
                 'description': 'Terra MODIS True Color (RGB) Imagery',
-                'website': 'https://worldview.earthdata.nasa.gov',
-                'satellite': 'Terra',
-                'instrument': 'MODIS',
+                    'website': 'https://worldview.earthdata.nasa.gov',
+                  'satellite': 'Terra',
+                 'instrument': 'MODIS',
             'acknowledgement': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
                 },
 
         'MYDRGB': {
                 'dataset_tag': 'MYDRGB',
-                'dict_key': 'myd_rgb',
+                   'dict_key': 'myd_rgb',
                 'description': 'Aqua MODIS True Color (RGB) Imagery',
-                'website': 'https://worldview.earthdata.nasa.gov',
-                'satellite': 'Aqua',
-                'instrument': 'MODIS',
+                    'website': 'https://worldview.earthdata.nasa.gov',
+                  'satellite': 'Aqua',
+                 'instrument': 'MODIS',
             'acknowledgement': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
                 },
 
         'MOD03': {
                 'dataset_tag': '61/MOD03',
-                'dict_key': 'mod_03',
+                   'dict_key': 'mod_03',
                 'description': 'Terra MODIS Geolocation Fields Product',
-                'website': 'http://dx.doi.org/10.5067/MODIS/MOD03.061',
-                'satellite': 'Terra',
-                'instrument': 'MODIS',
-                'reference': 'MODIS Characterization Support Team: MODIS Geolocation Fields Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD03.061 (last access: %s), 2017.' % date_today_str,
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MOD03.061',
+                  'satellite': 'Terra',
+                 'instrument': 'MODIS',
+                  'reference': 'MODIS Characterization Support Team: MODIS Geolocation Fields Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD03.061 (last access: %s), 2017.' % _date_today_,
                 },
 
         'MYD03': {
                 'dataset_tag': '61/MYD03',
-                'dict_key': 'myd_03',
+                   'dict_key': 'myd_03',
                 'description': 'Aqua MODIS Geolocation Fields Product',
-                'website': 'http://dx.doi.org/10.5067/MODIS/MYD03.061',
-                'satellite': 'Aqua',
-                'instrument': 'MODIS',
-                'reference': 'MODIS Characterization Support Team: MODIS Geolocation Fields Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD03.061 (last access: %s), 2017.' % date_today_str,
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MYD03.061',
+                  'satellite': 'Aqua',
+                 'instrument': 'MODIS',
+                  'reference': 'MODIS Characterization Support Team: MODIS Geolocation Fields Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD03.061 (last access: %s), 2017.' % _date_today_,
                 },
 
         'MOD02QKM': {
                 'dataset_tag': '61/MOD02QKM',
-                'dict_key': 'mod_02',
+                   'dict_key': 'mod_02',
                 'description': 'Terra MODIS Level 1b (250m) Calibrated Radiances Product',
-                'website': 'http://dx.doi.org/10.5067/MODIS/MOD02QKM.061',
-                'satellite': 'Terra',
-                'instrument': 'MODIS',
-                'reference': 'MODIS Characterization Support Team: MODIS 250m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD02QKM.061 (last access: %s), 2017.' % date_today_str,
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MOD02QKM.061',
+                  'satellite': 'Terra',
+                 'instrument': 'MODIS',
+                  'reference': 'MODIS Characterization Support Team: MODIS 250m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD02QKM.061 (last access: %s), 2017.' % _date_today_,
                 },
 
         'MYD02QKM': {
                 'dataset_tag': '61/MYD02QKM',
-                'dict_key': 'myd_02',
+                   'dict_key': 'myd_02',
                 'description': 'Aqua MODIS Level 1b (250m) Calibrated Radiances Product',
-                'website': 'http://dx.doi.org/10.5067/MODIS/MYD02QKM.061',
-                'satellite': 'Aqua',
-                'instrument': 'MODIS',
-                'reference': 'MODIS Characterization Support Team: MODIS 250m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD02QKM.061 (last access: %s), 2017.' % date_today_str,
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MYD02QKM.061',
+                  'satellite': 'Aqua',
+                 'instrument': 'MODIS',
+                  'reference': 'MODIS Characterization Support Team: MODIS 250m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD02QKM.061 (last access: %s), 2017.' % _date_today_,
                 },
 
         'MOD02HKM': {
                 'dataset_tag': '61/MOD02HKM',
-                'dict_key': 'mod_02',
+                   'dict_key': 'mod_02',
                 'description': 'Terra MODIS Level 1b (500m) Calibrated Radiances Product',
-                'website': 'http://dx.doi.org/10.5067/MODIS/MOD02HKM.061',
-                'satellite': 'Terra',
-                'instrument': 'MODIS',
-                'reference': 'MODIS Characterization Support Team: MODIS 500m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD02HKM.061 (last access: %s), 2017.' % date_today_str,
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MOD02HKM.061',
+                  'satellite': 'Terra',
+                 'instrument': 'MODIS',
+                  'reference': 'MODIS Characterization Support Team: MODIS 500m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD02HKM.061 (last access: %s), 2017.' % _date_today_,
                 },
 
         'MYD02HKM': {
                 'dataset_tag': '61/MYD02HKM',
-                'dict_key': 'myd_02',
+                   'dict_key': 'myd_02',
                 'description': 'Aqua MODIS Level 1b (250m) Calibrated Radiances Product',
-                'website': 'http://dx.doi.org/10.5067/MODIS/MYD02HKM.061',
-                'satellite': 'Aqua',
-                'instrument': 'MODIS',
-                'reference': 'MODIS Characterization Support Team: MODIS 500m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD02HKM.061 (last access: %s), 2017.' % date_today_str,
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MYD02HKM.061',
+                  'satellite': 'Aqua',
+                 'instrument': 'MODIS',
+                  'reference': 'MODIS Characterization Support Team: MODIS 500m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD02HKM.061 (last access: %s), 2017.' % _date_today_,
                 },
 
         'MOD021KM': {
                 'dataset_tag': '61/MOD021KM',
-                'dict_key': 'mod_02',
+                   'dict_key': 'mod_02',
                 'description': 'Terra MODIS Level 1b (1km) Calibrated Radiances Product',
-                'website': 'http://dx.doi.org/10.5067/MODIS/MOD021KM.061',
-                'satellite': 'Terra',
-                'instrument': 'MODIS',
-                'reference': 'MODIS Characterization Support Team: MODIS 1km Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD021KM.061 (last access: %s), 2017.' % date_today_str,
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MOD021KM.061',
+                  'satellite': 'Terra',
+                 'instrument': 'MODIS',
+                  'reference': 'MODIS Characterization Support Team: MODIS 1km Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD021KM.061 (last access: %s), 2017.' % _date_today_,
                 },
 
         'MYD021KM': {
-                'dataset_tag': '61/MYD02HKM',
-                'dict_key': 'myd_02',
+                'dataset_tag': '61/MYD021KM',
+                   'dict_key': 'myd_02',
                 'description': 'Aqua MODIS Level 1b (1km) Calibrated Radiances Product',
-                'website': 'http://dx.doi.org/10.5067/MODIS/MYD021KM.061',
-                'satellite': 'Aqua',
-                'instrument': 'MODIS',
-                'reference': 'MODIS Characterization Support Team: MODIS 1km Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD021KM.061 (last access: %s), 2017.' % date_today_str,
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MYD021KM.061',
+                  'satellite': 'Aqua',
+                 'instrument': 'MODIS',
+                  'reference': 'MODIS Characterization Support Team: MODIS 1km Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD021KM.061 (last access: %s), 2017.' % _date_today_,
                 },
 
         'MOD06_L2': {
                 'dataset_tag': '61/MOD06_L2',
-                'dict_key': 'mod_l2',
+                   'dict_key': 'mod_l2',
                 'description': 'Terra MODIS Atmosphere L2 Cloud Product',
-                'website': 'http://dx.doi.org/10.5067/MODIS/MOD06_L2.061',
-                'satellite': 'Terra',
-                'instrument': 'MODIS',
-                'reference': 'Platnick, S., Ackerman, S. A., King, M. D. , Meyer, K., Menzel, W. P. , Holz, R. E., Baum, B. A., and Yang, P., 2015: MODIS atmosphere L2 cloud product (06_L2), NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD06_L2.061 (last access: %s), 2015.' % date_today_str,
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MOD06_L2.061',
+                  'satellite': 'Terra',
+                 'instrument': 'MODIS',
+                  'reference': 'Platnick, S., Ackerman, S. A., King, M. D. , Meyer, K., Menzel, W. P. , Holz, R. E., Baum, B. A., and Yang, P., 2015: MODIS atmosphere L2 cloud product (06_L2), NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD06_L2.061 (last access: %s), 2015.' % _date_today_,
                 },
 
         'MYD06_L2': {
                 'dataset_tag': '61/MYD06_L2',
-                'dict_key': 'myd_02',
+                   'dict_key': 'myd_l2',
                 'description': 'Aqua MODIS Atmosphere L2 Cloud Product',
-                'website': 'http://dx.doi.org/10.5067/MODIS/MYD06_L2.061',
-                'satellite': 'Aqua',
-                'instrument': 'MODIS',
-                'reference': 'Platnick, S., Ackerman, S. A., King, M. D. , Meyer, K., Menzel, W. P. , Holz, R. E., Baum, B. A., and Yang, P., 2015: MODIS atmosphere L2 cloud product (06_L2), NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD06_L2.061 (last access: %s), 2015.' % date_today_str,
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MYD06_L2.061',
+                  'satellite': 'Aqua',
+                 'instrument': 'MODIS',
+                  'reference': 'Platnick, S., Ackerman, S. A., King, M. D. , Meyer, K., Menzel, W. P. , Holz, R. E., Baum, B. A., and Yang, P., 2015: MODIS atmosphere L2 cloud product (06_L2), NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD06_L2.061 (last access: %s), 2015.' % _date_today_,
                 },
 
         'MCD43A3': {
                 'dataset_tag': '61/MCD43A3',
-                'dict_key': 'mod_43',
+                   'dict_key': 'mod_43',
                 'description': 'MODIS BRDF/Albedo L3 Surface Product',
-                'website': 'https://doi.org/10.5067/MODIS/MCD43A3.061',
-                'satellite': 'Terra & Aqua',
-                'instrument': 'MODIS',
-                'reference': 'Schaaf, C., and Wang, Z.: MODIS/Terra+Aqua BRDF/Albedo Daily L3 Global - 500m V061, NASA EOSDIS Land Processes DAAC [data set], https://doi.org/10.5067/MODIS/MCD43A3.061 (last access: %s), 2021.' % date_today_str,
+                    'website': 'https://doi.org/10.5067/MODIS/MCD43A3.061',
+                  'satellite': 'Terra & Aqua',
+                 'instrument': 'MODIS',
+                  'reference': 'Schaaf, C., and Wang, Z.: MODIS/Terra+Aqua BRDF/Albedo Daily L3 Global - 500m V061, NASA EOSDIS Land Processes DAAC [data set], https://doi.org/10.5067/MODIS/MCD43A3.061 (last access: %s), 2021.' % _date_today_,
                 },
 
         'oco2_L1bScND': {
                 'dataset_tag': 'oco2_L1bScND',
-                'dict_key': 'oco_l1b',
+                   'dict_key': 'oco_l1b',
                 'description': 'OCO-2 L1B Calibrated Radiances Product',
-                'website': 'https://doi.org/10.5067/6O3GEUK7U2JG',
-                'satellite': 'OCO-2',
-                'instrument': 'OCO-2',
-                'reference': 'OCO-2 Science Team/Gunson, M., and Eldering, A.: OCO-2 Level 1B calibrated, geolocated science spectra, Retrospective Processing V10r, Goddard Earth Sciences Data and Information Services Center (GES DISC) [data set], Greenbelt, MD, USA, https://doi.org/10.5067/6O3GEUK7U2JG (last access: %s), 2019.' % date_today_str,
+                    'website': 'https://doi.org/10.5067/6O3GEUK7U2JG',
+                  'satellite': 'OCO-2',
+                 'instrument': 'OCO-2',
+                  'reference': 'OCO-2 Science Team/Gunson, M., and Eldering, A.: OCO-2 Level 1B calibrated, geolocated science spectra, Retrospective Processing V10r, Goddard Earth Sciences Data and Information Services Center (GES DISC) [data set], Greenbelt, MD, USA, https://doi.org/10.5067/6O3GEUK7U2JG (last access: %s), 2019.' % _date_today_,
                 },
 
         'oco2_L2MetND': {
-                'dataset_tag':    'oco2_L2MetND',
-                'dict_key':    'oco_met_l2',
+                'dataset_tag': 'oco2_L2MetND',
+                   'dict_key': 'oco_met_l2',
                 'description': 'OCO-2 L2 Meteorological Parameters Product',
-                'website':     'https://doi.org/10.5067/OJZZW0LIGSDH',
-                'satellite':   'OCO-2',
-                'instrument':  'OCO-2',
-                'reference':   'OCO-2 Science Team/Gunson, M., and Eldering, A.: OCO-2 Level 2 meteorological parameters interpolated from global assimilation model for each sounding, Retrospective Processing V10r, Goddard Earth Sciences Data and Information Services Center (GES DISC) [data set], Greenbelt, MD, USA, https://doi.org/10.5067/OJZZW0LIGSDH (last access: %s), 2019.' % date_today_str,
+                    'website': 'https://doi.org/10.5067/OJZZW0LIGSDH',
+                  'satellite': 'OCO-2',
+                 'instrument': 'OCO-2',
+                  'reference': 'OCO-2 Science Team/Gunson, M., and Eldering, A.: OCO-2 Level 2 meteorological parameters interpolated from global assimilation model for each sounding, Retrospective Processing V10r, Goddard Earth Sciences Data and Information Services Center (GES DISC) [data set], Greenbelt, MD, USA, https://doi.org/10.5067/OJZZW0LIGSDH (last access: %s), 2019.' % _date_today_,
                 },
 
         'oco2_L2StdND': {
                 'dataset_tag': 'oco2_L2StdND',
-                'dict_key': 'oco_ret_l2',
+                   'dict_key': 'oco_ret_l2',
                 'description': 'OCO-2 L2 XCO2 Retrieval Product',
-                'website': 'https://doi.org/10.5067/6SBROTA57TFH',
-                'satellite': 'OCO-2',
-                'instrument': 'OCO-2',
-                'reference': 'OCO-2 Science Team/Gunson, M., and Eldering, A.: OCO-2 Level 2 geolocated XCO2 retrievals results, physical model, Retrospective Processing V10r, Goddard Earth Sciences Data and Information Services Center (GES DISC) [data set], Greenbelt, MD, USA, https://doi.org/10.5067/6SBROTA57TFH (last access: %s), 2020.' % date_today_str,
+                    'website': 'https://doi.org/10.5067/6SBROTA57TFH',
+                  'satellite': 'OCO-2',
+                 'instrument': 'OCO-2',
+                  'reference': 'OCO-2 Science Team/Gunson, M., and Eldering, A.: OCO-2 Level 2 geolocated XCO2 retrievals results, physical model, Retrospective Processing V10r, Goddard Earth Sciences Data and Information Services Center (GES DISC) [data set], Greenbelt, MD, USA, https://doi.org/10.5067/6SBROTA57TFH (last access: %s), 2020.' % _date_today_,
                 },
 
         }
@@ -284,16 +284,16 @@ class SatelliteDownload:
             product_info = get_sat_info_from_product_tag(product)
             self.fnames[product_info['dict_key']] = []
             if self.verbose:
-                stdout = '=' * width + '\n\n%s\n' % product_info['description'].center(width)
+                stdout = '=' * _width_ + '\n\n%s\n' % product_info['description'].center(_width_)
                 print(stdout)
 
             # MODIS RGB imagery
             if 'RGB' in product.upper():
-                fnames = [er3t.util.download_worldview_rgb(date=self.date, 
-                                                           extent=self.extent, 
-                                                           fdir_out=self.fdir_out, 
-                                                           satellite=product_info['satellite'], 
-                                                           instrument=product_info['instrument'], 
+                fnames = [er3t.util.download_worldview_rgb(date=self.date,
+                                                           extent=self.extent,
+                                                           fdir_out=self.fdir_out,
+                                                           satellite=product_info['satellite'],
+                                                           instrument=product_info['instrument'],
                                                            coastline=True)]
                 self.fnames[product_info['dict_key']] += fnames
 
@@ -301,11 +301,11 @@ class SatelliteDownload:
             elif '43' in product.upper():
                 filename_tags_43 = er3t.util.get_sinusoidal_grid_tag(lon, lat)
                 for filename_tag in filename_tags_43:
-                    fnames = er3t.util.download_laads_https(date=self.date, 
-                                                            dataset_tag=product_info['dataset_tag'], 
-                                                            filename_tag=filename_tag, 
-                                                            day_interval=1, 
-                                                            fdir_out=self.fdir_out, 
+                    fnames = er3t.util.download_laads_https(date=self.date,
+                                                            dataset_tag=product_info['dataset_tag'],
+                                                            filename_tag=filename_tag,
+                                                            day_interval=1,
+                                                            fdir_out=self.fdir_out,
                                                             verbose=self.verbose)
                     self.fnames[product_info['dict_key']] += fnames
 
@@ -321,16 +321,16 @@ class SatelliteDownload:
                     print('Message [sdown]: Found %s %s overpasses\n' % (len(filename_tags_03), product_info['satellite']))
 
                 for filename_tag in filename_tags_03:
-                    fnames = er3t.util.download_laads_https(date=self.date, 
-                                                            dataset_tag=product_info['dataset_tag'], 
-                                                            filename_tag=filename_tag, 
-                                                            day_interval=1, 
-                                                            fdir_out=self.fdir_out, 
+                    fnames = er3t.util.download_laads_https(date=self.date,
+                                                            dataset_tag=product_info['dataset_tag'],
+                                                            filename_tag=filename_tag,
+                                                            day_interval=1,
+                                                            fdir_out=self.fdir_out,
                                                             verbose=self.verbose)
                     self.fnames[product_info['dict_key']] += fnames
 
             else:
-                msg = '\nError [sdown]: Cannot recognize satellite product from the given tag <%s>, abort...\nCurrently, only the following satellite products are supported by <sdown>:\n%s' % (product, '\n'.join(tags_support_.keys()))
+                msg = '\nError [sdown]: Cannot recognize satellite product from the given tag <%s>, abort...\nCurrently, only the following satellite products are supported by <sdown>:\n%s' % (product, '\n'.join(_sat_tags_support_.keys()))
                 raise OSError(msg)
         print('\nMessage [sdown]: Finished downloading MODIS files! You can find them in %s\n' % self.fdir_out)
 
@@ -340,8 +340,8 @@ def get_sat_info_from_product_tag(tag_):
     # make all variable names (keys) upper case
     #/----------------------------------------------------------------------------\#
     tags_support = {}
-    for key in tags_support_.keys():
-        tags_support[key.upper()] = tags_support_[key]
+    for key in _sat_tags_support_.keys():
+        tags_support[key.upper()] = _sat_tags_support_[key]
     #\----------------------------------------------------------------------------/#
 
     # return satellite product information
@@ -350,60 +350,16 @@ def get_sat_info_from_product_tag(tag_):
     if (tag in tags_support.keys()):
         return tags_support[tag]
     else:
-        msg = '\nError [sdown]: Cannot recognize satellite product from the given tag <%s>, abort...\nCurrently, only the following satellite products are supported by <sdown>:\n%s' % (tag_, '\n'.join(tags_support_.keys()))
+        msg = '\nError [sdown]: Cannot recognize satellite product from the given tag <%s>, abort...\nCurrently, only the following satellite products are supported by <sdown>:\n%s' % (tag_, '\n'.join(_sat_tags_support_.keys()))
         raise OSError(msg)
     #\----------------------------------------------------------------------------/#
 
 
-    # old
-    #/----------------------------------------------------------------------------\#
-    # sat_info = {}
-
-    # if any(pattern in tag for pattern in ['MOD']):
-    #     sat_info['satellite']  = 'Terra'
-    #     sat_info['instrument'] = 'MODIS'
-    # elif any(pattern in tag for pattern in ['MYD']):
-    #     sat_info['satellite']  = 'Aqua'
-    #     sat_info['instrument'] = 'MODIS'
-    # elif any(pattern in tag for pattern in ['MCD']):
-    #     sat_info['satellite']  = 'Terra and Aqua (Combined)'
-    #     sat_info['instrument'] = 'MODIS'
-    # elif any(pattern in tag for pattern in ['VNP']):
-    #     sat_info['satellite']  = 'Suomi NPP'
-    #     sat_info['instrument'] = 'VIIRS'
-    # elif any(pattern in tag for pattern in ['VJ102', 'VJ103']):
-    #     sat_info['satellite']  = 'NOAA 20'
-    #     sat_info['instrument'] = 'VIIRS'
-    #     raise OSError(msg)
-
-    # if any(pattern in tag for pattern in ['RGB']):
-    #     sat_info['product'] = 'True Color Imagery'
-    # elif any(pattern in tag for pattern in ['03']):
-    #     sat_info['product'] = 'Geolocation Fields Product'
-    # elif any(pattern in tag for pattern in ['02QKM', '02HKM', '021KM']):
-    #     sat_info['product'] = 'Calibrated Radiances Product'
-    # elif any(pattern in tag for pattern in ['06_L2']):
-    #     sat_info['product'] = 'L2 Cloud Product'
-    # elif any(pattern in tag for pattern in ['43A1', '43A2', '43A3', '43A4']):
-    #     sat_info['product'] = 'Surface BRDF/Albedo Product'
-
-    # return sat_info
-    #\----------------------------------------------------------------------------/#
-
 
 if __name__ == '__main__':
 
-    # sat_info = get_sat_info_from_product_tag('MYD03')
-    # print(sat_info)
-    # sat_info = get_sat_info_from_product_tag('MOD02QKM')
-    # print(sat_info)
-    # sat_info = get_sat_info_from_product_tag('MOD06_L2')
-    # print(sat_info)
-    # sat_info = get_sat_info_from_product_tag('MCD43A3')
-    # print(sat_info)
-
     parser = ArgumentParser(prog='sdown', formatter_class=RawTextHelpFormatter,
-                            description=description, usage='%(prog)s [-h] [--help] [-i]')
+                            description=_description_, usage='%(prog)s [-h] [--help] [-i]')
     parser.add_argument('-f', '--fdir', type=str, metavar='', default='modis-data',
                         help='Directory where the files will be downloaded\n'\
                              'By default, files will be downloaded to \'modis-data\'')

--- a/bin/sdown
+++ b/bin/sdown
@@ -46,8 +46,8 @@ _description_ = '=' * _width_ + '\n\n' + \
                 '=' * _width_ + '\n' + \
                 ' Satellite Data Product Download Tool '.center(_width_, '=') + '\n\n' + \
                 'Example Usage:\n'\
-                'sdown --date 20210523 --lons 30 35 --lats 0 10 --satellite aqua --products 06_l2 --fdir_out tmp-data\n'\
-                'sdown --date 20130714 --extent 30 35 0 10 --satellite terra --products l1b --fdir_out tmp-data\n'
+                'sdown --date 20210523 --lons 30 35 --lats 0 10 --products MOD06_L2 --fdir_out tmp-data\n'\
+                'sdown --date 20130714 --extent 30 35 0 10 --products MODRGB MYD02QKM --fdir_out tmp-data\n'
 
 # product tags
 # this <_sat_tags_support_> will be updated over time
@@ -245,7 +245,7 @@ class SatelliteDownload:
         else:
             sys.exit('\nError [sdown]: The provided lon/lat coordinates are incorrect, check again\n')
 
-        if (extent[0] >= extent[1]) or (extent[2] >= extent[3]):
+        if (self.extent[0] >= self.extent[1]) or (self.extent[2] >= self.extent[3]):
             msg = '\nError [sdown]: The given extents of lon/lat are incorrect: %s.\nPlease check to make sure extent is passed as `lon1 lon2 lat1 lat2` format i.e. West, East, South, North.\n' % self.extent
             sys.exit(msg)
 
@@ -375,15 +375,15 @@ if __name__ == '__main__':
                                 'Example:  --lats 25 30')
     required.add_argument('-p', '--products', type=str, nargs='+', metavar='',
                         help='Short prefix (case insensitive) for the product name. Currently supported products are:\n'\
-                        '02QKM: Level 1b 250m radiance product\n'\
-                        '02HKM: Level 1b 500m radiance product\n'\
-                        '021KM: Level 1b 1km radiance product\n'\
-                        '03:    Solar/viewing geometry product\n'\
-                        '06_L2: Level 2 cloud product\n'\
-                        '43:    Level 3 surface product MCD43A3\n'\
-                        'RGB:   True-Color RGB imagery, useful for visuzliation'
+                        'MxD02QKM: Level 1b 250m radiance product\n'\
+                        'MxD02HKM: Level 1b 500m radiance product\n'\
+                        'MxD021KM: Level 1b 1km radiance product\n'\
+                        'MxD03:    Solar/viewing geometry product\n'\
+                        'MxD06_L2: Level 2 cloud product\n'\
+                        'MCD43:    Level 3 surface product MCD43A3\n'\
+                        'MxDRGB:   True-Color RGB imagery, useful for visuzliation'
                         '\nTo download multiple products at a time:\n'\
-                        '--product 021km 02hkm 06_l2\n')
+                        '--product MOD021KM MYD02HKM MYD06_l2\n')
 
     args = parser.parse_args()
 

--- a/bin/sdown
+++ b/bin/sdown
@@ -351,39 +351,48 @@ def get_sat_info_from_product_tag(tag_):
 if __name__ == '__main__':
 
     parser = ArgumentParser(prog='sdown', formatter_class=RawTextHelpFormatter,
-                            description=_description_, usage='%(prog)s [-h] [--help] [-i]')
+                            description=_description_)
     parser.add_argument('-f', '--fdir', type=str, metavar='', default='modis-data',
                         help='Directory where the files will be downloaded\n'\
-                             'By default, files will be downloaded to \'modis-data\'')
+                        'By default, files will be downloaded to \'modis-data\'\n \n')
     parser.add_argument('-v', '--verbose', action='store_true',
-                        help='Pass --verbose if status of your request should be reported frequently.\n'\
-                             'This is disabled by default.')
+                        help='Pass --verbose if status of your request should be reported frequently.\n \n'\
+                        'This is disabled by default.\n \n')
     parser.add_argument('-r', '--run_demo', action='store_true',
-                        help='Pass --run_demo if you would like to run a demonstration of this tool.')
+                        help='Pass --run_demo if you would like to run a demonstration of this tool.\n \n')
     required = parser.add_argument_group('Required Arguments')
     required.add_argument('-d', '--date', type=str, metavar='',
                         help='Date for which you would like to download data. '\
-                        'Use yyyymmdd format.\nExample: --date 20210404')
+                        'Use yyyymmdd format.\n'\
+                        'Example: --date 20210404\n \n')
     required.add_argument('-e', '--extent', nargs='+', type=float, metavar='',
-                        help='Extent of region of interest lon1 lon2 lat1 lat2 in West East South North format.\n'\
-                                'Example:  --extent -10 -5 25 30')
+                        help='Extent of region of interest \nlon1 lon2 lat1 lat2 in West East South North format.\n'\
+                        'Example:  --extent -10 -5 25 30\n \n')
     required.add_argument('-x', '--lons', nargs='+', type=float, metavar='',
-                        help='The west-most and east-most longitudes of the region. Alternative to providing the first two terms in `extent`.\n'\
-                                'Example:  --lons -10 -5')
+                        help='The west-most and east-most longitudes of the region.\nAlternative to providing the first two terms in `extent`.\n'\
+                        'Example:  --lons -10 -5\n \n')
     required.add_argument('-y', '--lats', nargs='+', type=float, metavar='',
-                        help='The south-most and north-most latitudes of the region. Alternative to providing the last two terms in `extent`.\n'\
-                                'Example:  --lats 25 30')
+                        help='The south-most and north-most latitudes of the region.\nAlternative to providing the last two terms in `extent`.\n'\
+                        'Example:  --lats 25 30\n \n')
     required.add_argument('-p', '--products', type=str, nargs='+', metavar='',
-                        help='Short prefix (case insensitive) for the product name. Currently supported products are:\n'\
-                        'MxD02QKM: Level 1b 250m radiance product\n'\
-                        'MxD02HKM: Level 1b 500m radiance product\n'\
-                        'MxD021KM: Level 1b 1km radiance product\n'\
-                        'MxD03:    Solar/viewing geometry product\n'\
-                        'MxD06_L2: Level 2 cloud product\n'\
-                        'MCD43:    Level 3 surface product MCD43A3\n'\
-                        'MxDRGB:   True-Color RGB imagery, useful for visuzliation'
-                        '\nTo download multiple products at a time:\n'\
-                        '--product MOD021KM MYD02HKM MYD06_l2\n')
+                        help='Short prefix (case insensitive) for the product name.\n'\
+                        'Example:  --products MOD02QKM\n'
+                        'Currently supported products are:\n'\
+                        'MOD02QKM:  Level 1b 250m (Terra) radiance product\n'\
+                        'MYD02QKM:  Level 1b 250m (Aqua)  radiance product\n'\
+                        'MOD02HKM:  Level 1b 500m (Terra) radiance product\n'\
+                        'MYD02HKM:  Level 1b 500m (Aqua)  radiance product\n'\
+                        'MOD021KM:  Level 1b 1km (Terra)  radiance product\n'\
+                        'MYD021KM:  Level 1b 1km (Aqua)   radiance product\n'\
+                        'MOD06_L2:  Level 2 (Terra) cloud product\n'\
+                        'MYD06_L2:  Level 2 (Aqua)  cloud product\n'\
+                        'MOD03   :  Solar/viewing geometry (Terra) product\n'\
+                        'MYD03   :  Solar/viewing geometry (Aqua)  product\n'\
+                        'MODRGB  :  True-Color RGB (Terra) imagery, useful for visuzliation\n'\
+                        'MYDRGB  :  True-Color RGB (Aqua)  imagery, useful for visuzliation\n'\
+                        'MCD43   :  Level 3 surface product MCD43A3\n'\
+                        '\n\nTo download multiple products at a time:\n'\
+                        '--product MOD021KM MYD02HKM MYD06_l2\n \n')
 
     args = parser.parse_args()
 

--- a/bin/sdown
+++ b/bin/sdown
@@ -49,6 +49,13 @@ description = '=================================================================
               'sdown --date 20210523 --lons 30 35 --lats 0 10 --satellite aqua --products 06_l2 --fdir_out tmp-data\n'\
               'sdown --date 20130714 --extent 30 35 0 10 --satellite terra --products l1b --fdir_out tmp-data\n'
 
+description = '=' * width + '\n\n' + \
+              'Education and Research 3D Radiative Transfer Toolbox (EaR\u00b3T)'.center(width) + '\n\n' + \
+              '=' * width + '\n' + \
+              ' Satellite Data Product Download Tool '.center(width, '=') + '\n\n' + \
+              'Example Usage:\n'\
+              'sdown --date 20210523 --lons 30 35 --lats 0 10 --satellite aqua --products 06_l2 --fdir_out tmp-data\n'\
+              'sdown --date 20130714 --extent 30 35 0 10 --satellite terra --products l1b --fdir_out tmp-data\n'
 
 # product tags
 # this <tags_support_> will be updated over time

--- a/bin/sdown
+++ b/bin/sdown
@@ -4,7 +4,13 @@
 Downloads satellite data products for any user-specified date and geolocation location (lat/lon).
 
 Now supports:
-    MODIS data: MOD-RGB, MYD-RGB, MOD03, MOD02QKM, MOD02HKM, MOD021KM, MOD06_L2, ...
+    MODIS data: MOD-RGB,  MYD-RGB 
+                MOD03,    MYD03 
+                MOD02QKM, MYD02QKM
+                MOD02HKM, MYD02HKM
+                MOD021KM, MYD021KM
+                MOD06_L2, MYD06_L2
+                MCD43
     VIIRS data: ...
     OCO-2 data: ...
 
@@ -15,8 +21,8 @@ Authors:
     Hong Chen
 
 Example Usage:
-    sdown --date 20210523 --lons 30 35 --lats 0 10 --satellite aqua --products 06_l2 --fdir tmp-data
-    sdown --date 20130714 --extent 30 35 0 10 --satellite terra --products rgb 02hkm 06_l2 --fdir tmp-data
+    sdown --date 20210523 --lons 30 35 --lats 0 10 --products mod06_l2 --fdir tmp-data
+    sdown --date 20130714 --extent 30 35 0 10 --products modrgb myd02hkm myd06_l2 --fdir tmp-data
 
 To see a demonstration of how this tool works, use:
     sdown --run_demo
@@ -24,15 +30,15 @@ To see a demonstration of how this tool works, use:
 
 import os
 import sys
-import pickle
-import h5py
-from pyhdf.SD import SD, SDC
 from argparse import ArgumentParser, RawTextHelpFormatter
 import numpy as np
 import datetime
 
 
 import er3t
+
+# get width for stdout statements
+width = os.get_terminal_size().columns
 
 # set welcome text
 description = '===================================================================\n\n'\
@@ -44,11 +50,175 @@ description = '=================================================================
               'sdown --date 20130714 --extent 30 35 0 10 --satellite terra --products l1b --fdir_out tmp-data\n'
 
 
-product_options = ['02QKM', '02HKM', '021KM', '06_L2', '03', 'RGB', '43']
-product_names   = ['MODIS Level 1b Radiances (250 m)', 'MODIS Level 1b Radiances (500 m)', 'MODIS Level 1b Radiances (1 km)',
-                   'MODIS Level 2 Cloud Product', 'MODIS Solar/Viewing Geometries', 'MODIS True-Color RGB Imagery',
-                   'MODIS Level 2 Surface Reflectance/Albedo Product']
-product_dict    = dict(zip(product_options, product_names))
+# product tags
+# this <tags_support_> will be updated over time
+#/----------------------------------------------------------------------------\#
+date_today_str = datetime.date.today().strftime('%d %B, %Y')
+
+tags_support_ = {
+
+        'MODRGB': {
+                'dataset_tag': 'MODRGB',
+                'dict_key': 'mod_rgb',
+                'description': 'Terra MODIS True Color (RGB) Imagery',
+                'website': 'https://worldview.earthdata.nasa.gov',
+                'satellite': 'Terra',
+                'instrument': 'MODIS',
+            'acknowledgement': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
+                },
+
+        'MYDRGB': {
+                'dataset_tag': 'MYDRGB',
+                'dict_key': 'myd_rgb',
+                'description': 'Aqua MODIS True Color (RGB) Imagery',
+                'website': 'https://worldview.earthdata.nasa.gov',
+                'satellite': 'Aqua',
+                'instrument': 'MODIS',
+            'acknowledgement': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
+                },
+
+        'MOD03': {
+                'dataset_tag': '61/MOD03',
+                'dict_key': 'mod_03',
+                'description': 'Terra MODIS Geolocation Fields Product',
+                'website': 'http://dx.doi.org/10.5067/MODIS/MOD03.061',
+                'satellite': 'Terra',
+                'instrument': 'MODIS',
+                'reference': 'MODIS Characterization Support Team: MODIS Geolocation Fields Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD03.061 (last access: %s), 2017.' % date_today_str,
+                },
+
+        'MYD03': {
+                'dataset_tag': '61/MYD03',
+                'dict_key': 'myd_03',
+                'description': 'Aqua MODIS Geolocation Fields Product',
+                'website': 'http://dx.doi.org/10.5067/MODIS/MYD03.061',
+                'satellite': 'Aqua',
+                'instrument': 'MODIS',
+                'reference': 'MODIS Characterization Support Team: MODIS Geolocation Fields Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD03.061 (last access: %s), 2017.' % date_today_str,
+                },
+
+        'MOD02QKM': {
+                'dataset_tag': '61/MOD02QKM',
+                'dict_key': 'mod_02',
+                'description': 'Terra MODIS Level 1b (250m) Calibrated Radiances Product',
+                'website': 'http://dx.doi.org/10.5067/MODIS/MOD02QKM.061',
+                'satellite': 'Terra',
+                'instrument': 'MODIS',
+                'reference': 'MODIS Characterization Support Team: MODIS 250m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD02QKM.061 (last access: %s), 2017.' % date_today_str,
+                },
+
+        'MYD02QKM': {
+                'dataset_tag': '61/MYD02QKM',
+                'dict_key': 'myd_02',
+                'description': 'Aqua MODIS Level 1b (250m) Calibrated Radiances Product',
+                'website': 'http://dx.doi.org/10.5067/MODIS/MYD02QKM.061',
+                'satellite': 'Aqua',
+                'instrument': 'MODIS',
+                'reference': 'MODIS Characterization Support Team: MODIS 250m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD02QKM.061 (last access: %s), 2017.' % date_today_str,
+                },
+
+        'MOD02HKM': {
+                'dataset_tag': '61/MOD02HKM',
+                'dict_key': 'mod_02',
+                'description': 'Terra MODIS Level 1b (500m) Calibrated Radiances Product',
+                'website': 'http://dx.doi.org/10.5067/MODIS/MOD02HKM.061',
+                'satellite': 'Terra',
+                'instrument': 'MODIS',
+                'reference': 'MODIS Characterization Support Team: MODIS 500m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD02HKM.061 (last access: %s), 2017.' % date_today_str,
+                },
+
+        'MYD02HKM': {
+                'dataset_tag': '61/MYD02HKM',
+                'dict_key': 'myd_02',
+                'description': 'Aqua MODIS Level 1b (250m) Calibrated Radiances Product',
+                'website': 'http://dx.doi.org/10.5067/MODIS/MYD02HKM.061',
+                'satellite': 'Aqua',
+                'instrument': 'MODIS',
+                'reference': 'MODIS Characterization Support Team: MODIS 500m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD02HKM.061 (last access: %s), 2017.' % date_today_str,
+                },
+
+        'MOD021KM': {
+                'dataset_tag': '61/MOD021KM',
+                'dict_key': 'mod_02',
+                'description': 'Terra MODIS Level 1b (1km) Calibrated Radiances Product',
+                'website': 'http://dx.doi.org/10.5067/MODIS/MOD021KM.061',
+                'satellite': 'Terra',
+                'instrument': 'MODIS',
+                'reference': 'MODIS Characterization Support Team: MODIS 1km Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD021KM.061 (last access: %s), 2017.' % date_today_str,
+                },
+
+        'MYD021KM': {
+                'dataset_tag': '61/MYD02HKM',
+                'dict_key': 'myd_02',
+                'description': 'Aqua MODIS Level 1b (1km) Calibrated Radiances Product',
+                'website': 'http://dx.doi.org/10.5067/MODIS/MYD021KM.061',
+                'satellite': 'Aqua',
+                'instrument': 'MODIS',
+                'reference': 'MODIS Characterization Support Team: MODIS 1km Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD021KM.061 (last access: %s), 2017.' % date_today_str,
+                },
+
+        'MOD06_L2': {
+                'dataset_tag': '61/MOD06_L2',
+                'dict_key': 'mod_l2',
+                'description': 'Terra MODIS Atmosphere L2 Cloud Product',
+                'website': 'http://dx.doi.org/10.5067/MODIS/MOD06_L2.061',
+                'satellite': 'Terra',
+                'instrument': 'MODIS',
+                'reference': 'Platnick, S., Ackerman, S. A., King, M. D. , Meyer, K., Menzel, W. P. , Holz, R. E., Baum, B. A., and Yang, P., 2015: MODIS atmosphere L2 cloud product (06_L2), NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD06_L2.061 (last access: %s), 2015.' % date_today_str,
+                },
+
+        'MYD06_L2': {
+                'dataset_tag': '61/MYD06_L2',
+                'dict_key': 'myd_02',
+                'description': 'Aqua MODIS Atmosphere L2 Cloud Product',
+                'website': 'http://dx.doi.org/10.5067/MODIS/MYD06_L2.061',
+                'satellite': 'Aqua',
+                'instrument': 'MODIS',
+                'reference': 'Platnick, S., Ackerman, S. A., King, M. D. , Meyer, K., Menzel, W. P. , Holz, R. E., Baum, B. A., and Yang, P., 2015: MODIS atmosphere L2 cloud product (06_L2), NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD06_L2.061 (last access: %s), 2015.' % date_today_str,
+                },
+
+        'MCD43A3': {
+                'dataset_tag': '61/MCD43A3',
+                'dict_key': 'mod_43',
+                'description': 'MODIS BRDF/Albedo L3 Surface Product',
+                'website': 'https://doi.org/10.5067/MODIS/MCD43A3.061',
+                'satellite': 'Terra & Aqua',
+                'instrument': 'MODIS',
+                'reference': 'Schaaf, C., and Wang, Z.: MODIS/Terra+Aqua BRDF/Albedo Daily L3 Global - 500m V061, NASA EOSDIS Land Processes DAAC [data set], https://doi.org/10.5067/MODIS/MCD43A3.061 (last access: %s), 2021.' % date_today_str,
+                },
+
+        'oco2_L1bScND': {
+                'dataset_tag': 'oco2_L1bScND',
+                'dict_key': 'oco_l1b',
+                'description': 'OCO-2 L1B Calibrated Radiances Product',
+                'website': 'https://doi.org/10.5067/6O3GEUK7U2JG',
+                'satellite': 'OCO-2',
+                'instrument': 'OCO-2',
+                'reference': 'OCO-2 Science Team/Gunson, M., and Eldering, A.: OCO-2 Level 1B calibrated, geolocated science spectra, Retrospective Processing V10r, Goddard Earth Sciences Data and Information Services Center (GES DISC) [data set], Greenbelt, MD, USA, https://doi.org/10.5067/6O3GEUK7U2JG (last access: %s), 2019.' % date_today_str,
+                },
+
+        'oco2_L2MetND': {
+                'dataset_tag':    'oco2_L2MetND',
+                'dict_key':    'oco_met_l2',
+                'description': 'OCO-2 L2 Meteorological Parameters Product',
+                'website':     'https://doi.org/10.5067/OJZZW0LIGSDH',
+                'satellite':   'OCO-2',
+                'instrument':  'OCO-2',
+                'reference':   'OCO-2 Science Team/Gunson, M., and Eldering, A.: OCO-2 Level 2 meteorological parameters interpolated from global assimilation model for each sounding, Retrospective Processing V10r, Goddard Earth Sciences Data and Information Services Center (GES DISC) [data set], Greenbelt, MD, USA, https://doi.org/10.5067/OJZZW0LIGSDH (last access: %s), 2019.' % date_today_str,
+                },
+
+        'oco2_L2StdND': {
+                'dataset_tag': 'oco2_L2StdND',
+                'dict_key': 'oco_ret_l2',
+                'description': 'OCO-2 L2 XCO2 Retrieval Product',
+                'website': 'https://doi.org/10.5067/6SBROTA57TFH',
+                'satellite': 'OCO-2',
+                'instrument': 'OCO-2',
+                'reference': 'OCO-2 Science Team/Gunson, M., and Eldering, A.: OCO-2 Level 2 geolocated XCO2 retrievals results, physical model, Retrospective Processing V10r, Goddard Earth Sciences Data and Information Services Center (GES DISC) [data set], Greenbelt, MD, USA, https://doi.org/10.5067/6SBROTA57TFH (last access: %s), 2020.' % date_today_str,
+                },
+
+        }
+#\----------------------------------------------------------------------------/#
 
 
 class SatelliteDownload:
@@ -57,7 +227,6 @@ class SatelliteDownload:
             self,
             date=None,
             extent=None,
-            satellite=None,
             lons=None,
             lats=None,
             fdir_out=None,
@@ -65,10 +234,6 @@ class SatelliteDownload:
             verbose=False):
 
         # Error handling
-        if satellite.lower() not in ['aqua', 'terra']:
-            msg = '\nError [sdown]: Satellite must be either \'Aqua\' or \'Terra\'. %s is currently not supported\n' % satellite
-            sys.exit(msg)
-
         if len(products) == 0:
             sys.exit('\nError [sdown]: Please specify a product to download. We currently support %s\n' % product_options)
 
@@ -91,7 +256,6 @@ class SatelliteDownload:
                 print('\nMessage [sdown]: Created %s. Files will be downloaded to this directory\n' % fdir_out)
 
         self.date = datetime.datetime(int(date[:4]), int(date[4:6]), int(date[6:8]))
-        self.satellite = satellite.lower()
         self.products  = products
         self.fdir_out  = fdir_out
         self.verbose   = verbose
@@ -105,190 +269,66 @@ class SatelliteDownload:
         lat0 = np.linspace(self.extent[2], self.extent[3], 100)
         lon, lat = np.meshgrid(lon0, lat0, indexing='ij')
 
-        # create prefixes for the satellite products
-        if self.satellite == 'aqua':
-            sat_prefix = 'MYD'
-            # dataset_tags = ['61/MYD03', '61/MYD06_L2', '61/MYD02QKM']
-        elif self.satellite == 'terra':
-            sat_prefix = 'MOD'
-            # dataset_tags = ['61/MOD03', '61/MOD06_L2', '61/MOD02QKM']
-
-        filename_tags_03 = er3t.util.get_satfile_tag(self.date, lon, lat, satellite=self.satellite, instrument='modis')
-        if self.verbose:
-            print('===================================================================\n\n'\
-                 '\nMessage [satellite_download]: Found %s %s overpasses\n' % (len(filename_tags_03), self.satellite.capitalize()))
 
         # add product IDs
         self.fnames = {}
         for product in self.products:
-            if product.upper() not in product_options:
-                sys.exit('\nMessage [sdown]: Specified product %s cannot be downloaded. Currently supported products are \n%s\n' % (product, product_options))
 
+            product_info = get_sat_info_from_product_tag(product)
+            self.fnames[product_info['dict_key']] = []
             if self.verbose:
-                print('===================================================================\n\n'\
-                      '               %s                 \n'% product_dict[product.upper()])
+                stdout = '=' * width + '\n\n%s\n' % product_info['description'].center(width)
+                print(stdout)
 
             # MODIS RGB imagery
-            if product.upper() == 'RGB':
-                self.fnames['mod_rgb'] = []
-                fnames = [er3t.util.download_worldview_rgb(self.date, self.extent, fdir_out=self.fdir_out, satellite=self.satellite, instrument='modis', coastline=True)]
-                self.fnames['mod_rgb'] += fnames
+            if 'RGB' in product.upper():
+                fnames = [er3t.util.download_worldview_rgb(date=self.date, 
+                                                           extent=self.extent, 
+                                                           fdir_out=self.fdir_out, 
+                                                           satellite=product_info['satellite'], 
+                                                           instrument=product_info['instrument'], 
+                                                           coastline=True)]
+                self.fnames[product_info['dict_key']] += fnames
 
             # MODIS surface product
-            if product.upper() == '43':
-                self.fnames['mod_43'] = []
+            elif '43' in product.upper():
                 filename_tags_43 = er3t.util.get_sinusoidal_grid_tag(lon, lat)
                 for filename_tag in filename_tags_43:
-                    fnames = er3t.util.download_laads_https(self.date, '61/MCD43A3', filename_tag, day_interval=1, fdir_out=self.fdir_out, verbose=self.verbose)
-                    self.fnames['mod_43'] += fnames
+                    fnames = er3t.util.download_laads_https(date=self.date, 
+                                                            dataset_tag=product_info['dataset_tag'], 
+                                                            filename_tag=filename_tag, 
+                                                            day_interval=1, 
+                                                            fdir_out=self.fdir_out, 
+                                                            verbose=self.verbose)
+                    self.fnames[product_info['dict_key']] += fnames
 
-            # MODIS Level-2 cloud products
-            if product.upper() == '06_L2':
-                dataset_tag = '61/' + sat_prefix + product.upper()
-                self.fnames['mod_l2'] = []
+            # MODIS Level-1b radiances, Level-2 cloud products, and solar/viewing geoemetries
+            elif product.upper().endswith(('QKM', 'HKM', '1KM', '06_L2', '03')):
+                filename_tags_03 = er3t.util.get_satfile_tag(date=self.date,
+                                                             lon=lon,
+                                                             lat=lat,
+                                                             satellite=product_info['satellite'],
+                                                             instrument=product_info['instrument'],
+                                                             verbose=self.verbose)
+                if self.verbose:
+                    print('Message [sdown]: Found %s %s overpasses\n' % (len(filename_tags_03), product_info['satellite']))
+
                 for filename_tag in filename_tags_03:
-                    fnames = er3t.util.download_laads_https(self.date, dataset_tag, filename_tag, day_interval=1, fdir_out=self.fdir_out, verbose=self.verbose)
-                    self.fnames['mod_l2'] += fnames
+                    fnames = er3t.util.download_laads_https(date=self.date, 
+                                                            dataset_tag=product_info['dataset_tag'], 
+                                                            filename_tag=filename_tag, 
+                                                            day_interval=1, 
+                                                            fdir_out=self.fdir_out, 
+                                                            verbose=self.verbose)
+                    self.fnames[product_info['dict_key']] += fnames
 
-            # MODIS Level-1b radiances
-            if product.upper() in ['02QKM', '02HKM', '021KM']:
-                dataset_tag = '61/' + sat_prefix + product.upper()
-                self.fnames['mod_l2'] = []
-                for filename_tag in filename_tags_03:
-                    fnames = er3t.util.download_laads_https(self.date, dataset_tag, filename_tag, day_interval=1, fdir_out=self.fdir_out, verbose=self.verbose)
-                    self.fnames['mod_l2'] += fnames
-
-            # MODIS solar/viewing geometries product
-            if product.upper() == '03':
-                dataset_tag = '61/' + sat_prefix + product.upper()
-                self.fnames['mod_l2'] = []
-                for filename_tag in filename_tags_03:
-                    fnames = er3t.util.download_laads_https(self.date, dataset_tag, filename_tag, day_interval=1, fdir_out=self.fdir_out, verbose=self.verbose)
-                    self.fnames['mod_l2'] += fnames
-
+            else:
+                msg = '\nError [sdown]: Cannot recognize satellite product from the given tag <%s>, abort...\nCurrently, only the following satellite products are supported by <sdown>:\n%s' % (product, '\n'.join(tags_support_.keys()))
+                raise OSError(msg)
         print('\nMessage [sdown]: Finished downloading MODIS files! You can find them in %s\n' % self.fdir_out)
 
 
 def get_sat_info_from_product_tag(tag_):
-
-    date_today_str = datetime.date.today().strftime('%d %B, %Y')
-
-    # this <tags_support_> will be updated over time
-    #/----------------------------------------------------------------------------\#
-    tags_support_ = {
-
-               'MODRGB': {
-                    'name_tag': 'MODRGB',
-                 'description': 'Terra MODIS True Color (RGB) Imagery',
-                     'website': 'https://worldview.earthdata.nasa.gov',
-                   'satellite': 'Terra',
-                  'instrument': 'MODIS',
-             'acknowledgement': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
-                   },
-
-
-               'MOD03': {
-                    'name_tag': 'MOD03',
-                 'description': 'Terra MODIS Geolocation Fields Product',
-                     'website': 'http://dx.doi.org/10.5067/MODIS/MOD03.061',
-                   'satellite': 'Terra',
-                  'instrument': 'MODIS',
-                   'reference': 'MODIS Characterization Support Team: MODIS Geolocation Fields Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD03.061 (last access: %s), 2017.' % date_today_str,
-                   },
-
-            'MOD02QKM': {
-                    'name_tag': 'MOD02QKM',
-                 'description': 'Terra MODIS 250m Calibrated Radiances Product',
-                     'website': 'http://dx.doi.org/10.5067/MODIS/MOD02QKM.061',
-                   'satellite': 'Terra',
-                  'instrument': 'MODIS',
-                   'reference': 'MODIS Characterization Support Team: MODIS 250m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD02QKM.061 (last access: %s), 2017.' % date_today_str,
-                   },
-
-            'MOD06_L2': {
-                    'name_tag': 'MOD06_L2',
-                 'description': 'Terra MODIS Atmosphere L2 Cloud Product',
-                     'website': 'http://dx.doi.org/10.5067/MODIS/MOD06_L2.061',
-                   'satellite': 'Terra',
-                  'instrument': 'MODIS',
-                   'reference': 'Platnick, S., Ackerman, S. A., King, M. D. , Meyer, K., Menzel, W. P. , Holz, R. E., Baum, B. A., and Yang, P., 2015: MODIS atmosphere L2 cloud product (06_L2), NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD06_L2.061 (last access: %s), 2015.' % date_today_str,
-                   },
-
-               'MYDRGB': {
-                    'name_tag': 'MYDRGB',
-                 'description': 'Aqua MODIS True Color (RGB) Imagery',
-                     'website': 'https://worldview.earthdata.nasa.gov',
-                   'satellite': 'Aqua',
-                  'instrument': 'MODIS',
-             'acknowledgement': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
-                   },
-
-               'MYD03': {
-                    'name_tag': 'MYD03',
-                 'description': 'Aqua MODIS Geolocation Fields Product',
-                     'website': 'http://dx.doi.org/10.5067/MODIS/MYD03.061',
-                   'satellite': 'Aqua',
-                  'instrument': 'MODIS',
-                   'reference': 'MODIS Characterization Support Team: MODIS Geolocation Fields Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD03.061 (last access: %s), 2017.' % date_today_str,
-                   },
-
-            'MYD02QKM': {
-                    'name_tag': 'MYD02QKM',
-                 'description': 'Aqua MODIS 250m Calibrated Radiances Product',
-                     'website': 'http://dx.doi.org/10.5067/MODIS/MYD02QKM.061',
-                   'satellite': 'Aqua',
-                  'instrument': 'MODIS',
-                   'reference': 'MODIS Characterization Support Team: MODIS 250m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD02QKM.061 (last access: %s), 2017.' % date_today_str,
-                   },
-
-            'MYD06_L2': {
-                    'name_tag': 'MYD06_L2',
-                 'description': 'Aqua MODIS Atmosphere L2 Cloud Product',
-                     'website': 'http://dx.doi.org/10.5067/MODIS/MYD06_L2.061',
-                   'satellite': 'Aqua',
-                  'instrument': 'MODIS',
-                   'reference': 'Platnick, S., Ackerman, S. A., King, M. D. , Meyer, K., Menzel, W. P. , Holz, R. E., Baum, B. A., and Yang, P., 2015: MODIS atmosphere L2 cloud product (06_L2), NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD06_L2.061 (last access: %s), 2015.' % date_today_str,
-                   },
-
-            'MCD43A3': {
-                    'name_tag': 'MCD43A3',
-                 'description': 'MODIS BRDF/Albedo L3 Surface Product',
-                     'website': 'https://doi.org/10.5067/MODIS/MCD43A3.061',
-                   'satellite': 'Terra & Aqua',
-                  'instrument': 'MODIS',
-                   'reference': 'Schaaf, C., and Wang, Z.: MODIS/Terra+Aqua BRDF/Albedo Daily L3 Global - 500m V061, NASA EOSDIS Land Processes DAAC [data set], https://doi.org/10.5067/MODIS/MCD43A3.061 (last access: %s), 2021.' % date_today_str,
-                   },
-
-            'oco2_L1bScND': {
-                    'name_tag': 'oco2_L1bScND',
-                 'description': 'OCO-2 L1B Calibrated Radiances Product',
-                     'website': 'https://doi.org/10.5067/6O3GEUK7U2JG',
-                   'satellite': 'OCO-2',
-                  'instrument': 'OCO-2',
-                   'reference': 'OCO-2 Science Team/Gunson, M., and Eldering, A.: OCO-2 Level 1B calibrated, geolocated science spectra, Retrospective Processing V10r, Goddard Earth Sciences Data and Information Services Center (GES DISC) [data set], Greenbelt, MD, USA, https://doi.org/10.5067/6O3GEUK7U2JG (last access: %s), 2019.' % date_today_str,
-                   },
-
-            'oco2_L2MetND': {
-                    'name_tag': 'oco2_L2MetND',
-                 'description': 'OCO-2 L2 Meteorological Parameters Product',
-                     'website': 'https://doi.org/10.5067/OJZZW0LIGSDH',
-                   'satellite': 'OCO-2',
-                  'instrument': 'OCO-2',
-                   'reference': 'OCO-2 Science Team/Gunson, M., and Eldering, A.: OCO-2 Level 2 meteorological parameters interpolated from global assimilation model for each sounding, Retrospective Processing V10r, Goddard Earth Sciences Data and Information Services Center (GES DISC) [data set], Greenbelt, MD, USA, https://doi.org/10.5067/OJZZW0LIGSDH (last access: %s), 2019.' % date_today_str,
-                   },
-
-            'oco2_L2StdND': {
-                    'name_tag': 'oco2_L2StdND',
-                 'description': 'OCO-2 L2 XCO2 Retrieval Product',
-                     'website': 'https://doi.org/10.5067/6SBROTA57TFH',
-                   'satellite': 'OCO-2',
-                  'instrument': 'OCO-2',
-                   'reference': 'OCO-2 Science Team/Gunson, M., and Eldering, A.: OCO-2 Level 2 geolocated XCO2 retrievals results, physical model, Retrospective Processing V10r, Goddard Earth Sciences Data and Information Services Center (GES DISC) [data set], Greenbelt, MD, USA, https://doi.org/10.5067/6SBROTA57TFH (last access: %s), 2020.' % date_today_str,
-                   },
-
-            }
-    #\----------------------------------------------------------------------------/#
-
 
     # make all variable names (keys) upper case
     #/----------------------------------------------------------------------------\#
@@ -296,7 +336,6 @@ def get_sat_info_from_product_tag(tag_):
     for key in tags_support_.keys():
         tags_support[key.upper()] = tags_support_[key]
     #\----------------------------------------------------------------------------/#
-
 
     # return satellite product information
     #/----------------------------------------------------------------------------\#
@@ -379,9 +418,6 @@ if __name__ == '__main__':
     required.add_argument('-y', '--lats', nargs='+', type=float, metavar='',
                         help='The south-most and north-most latitudes of the region. Alternative to providing the last two terms in `extent`.\n'\
                                 'Example:  --lats 25 30')
-    required.add_argument('-s','--satellite', type=str, metavar='',
-                        help='One of \'Aqua\' or \'Terra\'. Case insensitive. \n'\
-                             'Example: --satellite terra')
     required.add_argument('-p', '--products', type=str, nargs='+', metavar='',
                         help='Short prefix (case insensitive) for the product name. Currently supported products are:\n'\
                         '02QKM: Level 1b 250m radiance product\n'\
@@ -389,7 +425,7 @@ if __name__ == '__main__':
                         '021KM: Level 1b 1km radiance product\n'\
                         '03:    Solar/viewing geometry product\n'\
                         '06_L2: Level 2 cloud product\n'\
-                        '43:    Level 2 surface product MCD43A3\n'\
+                        '43:    Level 3 surface product MCD43A3\n'\
                         'RGB:   True-Color RGB imagery, useful for visuzliation'
                         '\nTo download multiple products at a time:\n'\
                         '--product 021km 02hkm 06_l2\n')
@@ -401,16 +437,14 @@ if __name__ == '__main__':
         extent    = [-79.4, -71.1, 21.6, 25.8]
         lons      = None
         lats      = None
-        satellite = 'aqua'
         fdir      = 'tmp-data'
-        products  = ['RGB', '02QKM']
+        products  = ['MODRGB', 'MYD02QKM']
         verbose   = 1
 
         sat0 = SatelliteDownload(date=date,
                                  extent=extent,
                                  lons=lons,
                                  lats=lats,
-                                 satellite=satellite,
                                  fdir_out=fdir,
                                  products=products,
                                  verbose=verbose)
@@ -419,7 +453,6 @@ if __name__ == '__main__':
                                 extent=args.extent,
                                 lons=args.lons,
                                 lats=args.lats,
-                                satellite=args.satellite,
                                 fdir_out=args.fdir,
                                 products=args.products,
                                 verbose=args.verbose)

--- a/bin/sdown
+++ b/bin/sdown
@@ -41,14 +41,6 @@ import er3t
 _width_ = os.get_terminal_size().columns
 
 # set welcome text
-_description_ = '===================================================================\n\n'\
-                '    Education and Research 3D Radiative Transfer Toolbox (EaR\u00b3T)  \n\n'\
-                '===================================================================\n'\
-                '============== Satellite Data Product Download Tool ===============\n'\
-                'Example Usage:\n'\
-                'sdown --date 20210523 --lons 30 35 --lats 0 10 --satellite aqua --products 06_l2 --fdir_out tmp-data\n'\
-                'sdown --date 20130714 --extent 30 35 0 10 --satellite terra --products l1b --fdir_out tmp-data\n'
-
 _description_ = '=' * _width_ + '\n\n' + \
                 'Education and Research 3D Radiative Transfer Toolbox (EaR\u00b3T)'.center(_width_) + '\n\n' + \
                 '=' * _width_ + '\n' + \

--- a/er3t/util/modis.py
+++ b/er3t/util/modis.py
@@ -26,7 +26,6 @@ class modis_l1b:
 
     Input:
         fnames=     : keyword argument, default=None, Python list of the file path of the original HDF4 files
-        overwrite=  : keyword argument, default=False, whether to overwrite or not
         extent=     : keyword argument, default=None, region to be cropped, defined by [westmost, eastmost, southmost, northmost]
         resolution= : keyword argument, default=None, data spatial resolution in km, can be detected from filename
         verbose=    : keyword argument, default=False, verbose tag
@@ -48,14 +47,11 @@ class modis_l1b:
                  fnames    = None, \
                  extent    = None, \
                  resolution= None, \
-                 quiet     = True, \
                  verbose   = False):
 
         self.fnames     = fnames      # file name of the hdf files
         self.extent     = extent      # specified region [westmost, eastmost, southmost, northmost]
         self.verbose    = verbose     # verbose tag
-        self.quiet      = quiet       # quiet tag
-
 
         if resolution is None:
             filename = os.path.basename(fnames[0]).lower()
@@ -84,6 +80,7 @@ class modis_l1b:
             ['rad']
             ['ref']
             ['cnt']
+            ['uct']
         """
 
         try:

--- a/er3t/util/modis.py
+++ b/er3t/util/modis.py
@@ -76,7 +76,7 @@ class modis_l1b:
     def read(self, fname):
 
         """
-        Read radiance/reflectance/corrected counts from the MODIS L1B data
+        Read radiance/reflectance/corrected counts along with their uncertainties from the MODIS L1B data
         self.data
             ['lon']
             ['lat']
@@ -338,8 +338,8 @@ class modis_l2:
 
         else:
 
-            lon_range = [self.extent[0], self.extent[1]]
-            lat_range = [self.extent[2], self.extent[3]]
+            lon_range = [self.extent[0] - 0.01, self.extent[1] + 0.01]
+            lat_range = [self.extent[2] - 0.01, self.extent[3] + 0.01]
 
         logic     = (lon>=lon_range[0]) & (lon<=lon_range[1]) & (lat>=lat_range[0]) & (lat<=lat_range[1])
         lon       = lon[logic]
@@ -770,8 +770,8 @@ class modis_03:
 
         else:
 
-            lon_range = [self.extent[0], self.extent[1]]
-            lat_range = [self.extent[2], self.extent[3]]
+            lon_range = [self.extent[0] - 0.01, self.extent[1] + 0.01]
+            lat_range = [self.extent[2] - 0.01, self.extent[3] + 0.01]
 
         logic     = (lon>=lon_range[0]) & (lon<=lon_range[1]) & (lat>=lat_range[0]) & (lat<=lat_range[1])
         lon       = lon[logic]
@@ -918,8 +918,8 @@ class modis_09a1:
             lon_range = [-180.0, 180.0]
             lat_range = [-90.0 , 90.0]
         else:
-            lon_range = [self.extent[0], self.extent[1]]
-            lat_range = [self.extent[2], self.extent[3]]
+            lon_range = [self.extent[0] - 0.01, self.extent[1] + 0.01]
+            lat_range = [self.extent[2] - 0.01, self.extent[3] + 0.01]
 
         lon   = LonLat[..., 0]
         lat   = LonLat[..., 1]
@@ -937,7 +937,7 @@ class modis_09a1:
         try:
             from pyhdf.SD import SD, SDC
         except ImportError:
-            msg = 'Warning [modis_l1b]: To use \'modis_l1b\', \'pyhdf\' needs to be installed.'
+            msg = 'Warning [modis_09a1]: To use \'modis_09a1\', \'pyhdf\' needs to be installed.'
             raise ImportError(msg)
 
         f     = SD(fname, SDC.READ)
@@ -1046,8 +1046,8 @@ class modis_43a3:
             lon_range = [-180.0, 180.0]
             lat_range = [-90.0 , 90.0]
         else:
-            lon_range = [self.extent[0], self.extent[1]]
-            lat_range = [self.extent[2], self.extent[3]]
+            lon_range = [self.extent[0] - 0.01, self.extent[1] + 0.01]
+            lat_range = [self.extent[2] - 0.01, self.extent[3] + 0.01]
 
         lon   = LonLat[..., 0]
         lat   = LonLat[..., 1]

--- a/er3t/util/modis.py
+++ b/er3t/util/modis.py
@@ -124,7 +124,7 @@ class modis_l1b:
                 lat       = self.f03.data['lat']['data']
                 logic     = self.f03.logic[find_fname_match(fname, self.f03.logic.keys())]['1km']
             else:
-                sys.exit('Error   [modis_l1b]: \'resolution=%.1f\' has not been implemented.' % self.resolution)
+                sys.exit('Error   [modis_l1b]: \'resolution=%f\' has not been implemented without geolocation file being specified.' % self.resolution)
 
         else:
             sys.exit('Error   [modis_l1b]: \'resolution=%f\' has not been implemented.' % self.resolution)
@@ -132,7 +132,7 @@ class modis_l1b:
 
         # 1. If region (extent=) is specified, filter data within the specified region
         # 2. If region (extent=) is not specified, filter invalid data
-        # +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+        #/----------------------------------------------------------------------------\# 
         if self.extent is None:
 
             if 'actual_range' in lon0.attributes().keys():
@@ -157,7 +157,7 @@ class modis_l1b:
 
 
         # Calculate 1. radiance, 2. reflectance, 3. corrected counts from the raw data
-        # +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+        #/----------------------------------------------------------------------------\#
         raw = raw0[:][:, logic]
         rad = np.zeros(raw.shape, dtype=np.float64)
         ref = np.zeros(raw.shape, dtype=np.float64)
@@ -321,7 +321,7 @@ class modis_l2:
 
         # 1. If region (extent=) is specified, filter data within the specified region
         # 2. If region (extent=) is not specified, filter invalid data
-        # +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+        #/----------------------------------------------------------------------------\#
         lon, lat  = upscale_modis_lonlat(lon0[:], lat0[:], scale=5, extra_grid=True)
 
         if self.extent is None:
@@ -354,7 +354,7 @@ class modis_l2:
 
 
         # Calculate 1. cot, 2. cer, 3. ctp
-        # +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+        #/--------------------------------\#
         ctp0_data     = get_data_h4(ctp0)
         cot0_data     = get_data_h4(cot0)
         cer0_data     = get_data_h4(cer0)
@@ -581,7 +581,7 @@ class modis_35_l2:
 
         # 1. If region (extent=) is specified, filter data within the specified region
         # 2. If region (extent=) is not specified, filter invalid data
-        # +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+        #/----------------------------------------------------------------------------\#
         lon, lat  = upscale_modis_lonlat(lon0[:], lat0[:], scale=5, extra_grid=True)
 
         if self.extent is None:
@@ -598,8 +598,8 @@ class modis_35_l2:
 
         else:
 
-            lon_range = [self.extent[0], self.extent[1]]
-            lat_range = [self.extent[2], self.extent[3]]
+            lon_range = [self.extent[0] - 0.01, self.extent[1] + 0.01]
+            lat_range = [self.extent[2] - 0.01, self.extent[3] + 0.01]
 
         logic     = (lon>=lon_range[0]) & (lon<=lon_range[1]) & (lat>=lat_range[0]) & (lat<=lat_range[1])
         lon       = lon[logic]
@@ -614,8 +614,8 @@ class modis_35_l2:
         
         # -------------------------------------------------------------------------------------------------
 
-        # Get cloud mask and flag fields 
-        # +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+        # Get cloud mask and flag fields
+        #/-----------------------------\#
         cm0_data = get_data_h4(cld_msk0)
         qa0_data = get_data_h4(qa0)
         cm = cm0_data.copy()
@@ -626,7 +626,7 @@ class modis_35_l2:
         cm = cm.reshape((cm.size, 1))
         cloud_mask_flag, day_night_flag, sunglint_flag, snow_ice_flag, land_water_cat, fov_qa_cat = self.extract_data(cm)
         
-        qa = qa[:, :, 0] # read only the first byte for confidence (indexed differently from cloud mask sds)
+        qa = qa[:, :, 0] # read only the first byte for confidence (indexed differently from cloud mask SDS)
         qa = np.array(qa[logic], dtype='uint8')
         qa = qa.reshape((qa.size, 1))
         use_qa, confidence_qa = self.quality_assurance(qa)
@@ -752,7 +752,7 @@ class modis_03:
 
         # 1. If region (extent=) is specified, filter data within the specified region
         # 2. If region (extent=) is not specified, filter invalid data
-        # +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+        #/----------------------------------------------------------------------------\#
         lon = lon0[:]
         lat = lat0[:]
 
@@ -780,7 +780,7 @@ class modis_03:
 
 
         # Calculate 1. sza, 2. saa, 3. vza, 4. vaa
-        # +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+        #/---------------------------------------\#
         sza0_data = get_data_h4(sza0)
         saa0_data = get_data_h4(saa0)
         vza0_data = get_data_h4(vza0)

--- a/er3t/util/modis.py
+++ b/er3t/util/modis.py
@@ -12,7 +12,7 @@ from er3t.util import check_equal, get_doy_tag, get_data_h4
 
 
 
-__all__ = ['modis_l1b', 'modis_l2', 'modis_03', 'modis_09a1', 'modis_43a3', 'modis_tiff', 'upscale_modis_lonlat', \
+__all__ = ['modis_l1b', 'modis_l2', 'modis_35_l2', 'modis_03', 'modis_09a1', 'modis_43a3', 'modis_tiff', 'upscale_modis_lonlat', \
            'download_modis_rgb', 'download_modis_https', 'cal_sinusoidal_grid', 'get_sinusoidal_grid_tag']
 
 
@@ -46,15 +46,12 @@ class modis_l1b:
 
     def __init__(self, \
                  fnames    = None, \
-                 f03       = None, \
                  extent    = None, \
                  resolution= None, \
-                 overwrite = False,\
                  quiet     = True, \
                  verbose   = False):
 
         self.fnames     = fnames      # file name of the hdf files
-        self.f03        = f03         # geolocation file
         self.extent     = extent      # specified region [westmost, eastmost, southmost, northmost]
         self.verbose    = verbose     # verbose tag
         self.quiet      = quiet       # quiet tag
@@ -105,27 +102,19 @@ class modis_l1b:
         if check_equal(self.resolution, 0.25):
             lon, lat  = upscale_modis_lonlat(lon0[:], lat0[:], scale=4, extra_grid=False)
             raw0      = f.select('EV_250_RefSB')
+            uct0      = f.select('EV_250_RefSB_Uncert_Indexes')
             wvl       = np.array([650.0, 860.0])
-            do_region = True
 
         # when resolution equals to 500 m
         elif check_equal(self.resolution, 0.5):
             lon, lat  = upscale_modis_lonlat(lon0[:], lat0[:], scale=2, extra_grid=False)
             raw0      = f.select('EV_500_RefSB')
+            uct0      = f.select('EV_500_RefSB_Uncert_Indexes')
             wvl       = np.array([470.0, 555.0, 1240.0, 1640.0, 2130.0])
-            do_region = True
 
         # when resolution equals to 1000 m
         elif check_equal(self.resolution, 1.0):
-            if self.f03 is not None:
-                raw0      = f.select('EV_250_Aggr1km_RefSB')
-                wvl       = np.array([650.0, 860.0])
-                do_region = False
-                lon       = self.f03.data['lon']['data']
-                lat       = self.f03.data['lat']['data']
-                logic     = self.f03.logic[find_fname_match(fname, self.f03.logic.keys())]['1km']
-            else:
-                sys.exit('Error   [modis_l1b]: \'resolution=%f\' has not been implemented without geolocation file being specified.' % self.resolution)
+            sys.exit('Error   [modis_l1b]: \'resolution=%.1f\' has not been implemented.' % self.resolution)
 
         else:
             sys.exit('Error   [modis_l1b]: \'resolution=%f\' has not been implemented.' % self.resolution)
@@ -133,7 +122,7 @@ class modis_l1b:
 
         # 1. If region (extent=) is specified, filter data within the specified region
         # 2. If region (extent=) is not specified, filter invalid data
-        #/----------------------------------------------------------------------------\#
+        # +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
         if self.extent is None:
 
             if 'actual_range' in lon0.attributes().keys():
@@ -148,45 +137,61 @@ class modis_l1b:
 
         else:
 
-            lon_range = [self.extent[0]-0.01, self.extent[1]+0.01]
-            lat_range = [self.extent[2]-0.01, self.extent[3]+0.01]
+            lon_range = [self.extent[0], self.extent[1]]
+            lat_range = [self.extent[2], self.extent[3]]
 
-        if do_region:
-            logic     = (lon>=lon_range[0]) & (lon<=lon_range[1]) & (lat>=lat_range[0]) & (lat<=lat_range[1])
-            lon       = lon[logic]
-            lat       = lat[logic]
-        #\----------------------------------------------------------------------------/#
+        logic     = (lon>=lon_range[0]) & (lon<=lon_range[1]) & (lat>=lat_range[0]) & (lat<=lat_range[1])
+        lon       = lon[logic]
+        lat       = lat[logic]
+        # -------------------------------------------------------------------------------------------------
 
 
         # Calculate 1. radiance, 2. reflectance, 3. corrected counts from the raw data
-        #/----------------------------------------------------------------------------\#
+        # +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
         raw = raw0[:][:, logic]
         rad = np.zeros(raw.shape, dtype=np.float64)
         ref = np.zeros(raw.shape, dtype=np.float64)
         cnt = np.zeros(raw.shape, dtype=np.float64)
 
+        # save offsets and scaling factors
+        rad_off = raw0.attributes()['radiance_offsets']
+        rad_sca = raw0.attributes()['radiance_scales']
+
+        ref_off = raw0.attributes()['reflectance_offsets']
+        ref_sca = raw0.attributes()['reflectance_scales']
+
+        cnt_off = raw0.attributes()['corrected_counts_offsets']
+        cnt_sca = raw0.attributes()['corrected_counts_scales']
+
+        uct_spc = uct0.attributes()['specified_uncertainty']
+        uct_sca = uct0.attributes()['scaling_factor']
+
+
+        # Calculate uncertainty 
+        uct     = uct0[:][:, logic]
+        uct_pct = np.zeros(uct.shape, dtype=np.float64)
+
         for i in range(raw.shape[0]):
 
-            rad[i, ...]  = (raw[i, ...] - raw0.attributes()['radiance_offsets'][i])         * raw0.attributes()['radiance_scales'][i]
-            rad[i, ...] /= 1000.0 # convert to W/m^2/nm/sr
-            ref[i, ...]  = (raw[i, ...] - raw0.attributes()['reflectance_offsets'][i])      * raw0.attributes()['reflectance_scales'][i]
-            cnt[i, ...]  = (raw[i, ...] - raw0.attributes()['corrected_counts_offsets'][i]) * raw0.attributes()['corrected_counts_scales'][i]
-
+            rad[i, ...]       = (raw[i, ...] - rad_off[i]) * rad_sca[i]
+            rad[i, ...]      /= 1000.0 # convert to W/m^2/nm/sr
+            ref[i, ...]       = (raw[i, ...] - ref_off[i]) * ref_sca[i]
+            cnt[i, ...]       = (raw[i, ...] - cnt_off[i]) * cnt_sca[i]
+            uct_pct[i, ...]   = uct_spc[i] * np.exp(uct[i] / uct_sca[i]) # convert to percentage
+        
         f.end()
-        #\----------------------------------------------------------------------------/#
+        # -------------------------------------------------------------------------------------------------
 
 
 
         if hasattr(self, 'data'):
 
-            if do_region:
-                self.data['lon'] = dict(name='Longitude'               , data=np.hstack((self.data['lon']['data'], lon)), units='degrees')
-                self.data['lat'] = dict(name='Latitude'                , data=np.hstack((self.data['lat']['data'], lat)), units='degrees')
-
+            self.data['lon'] = dict(name='Longitude'               , data=np.hstack((self.data['lon']['data'], lon)), units='degrees')
+            self.data['lat'] = dict(name='Latitude'                , data=np.hstack((self.data['lat']['data'], lat)), units='degrees')
             self.data['rad'] = dict(name='Radiance'                , data=np.hstack((self.data['rad']['data'], rad)), units='W/m^2/nm/sr')
             self.data['ref'] = dict(name='Reflectance (x cos(SZA))', data=np.hstack((self.data['ref']['data'], ref)), units='N/A')
             self.data['cnt'] = dict(name='Corrected Counts'        , data=np.hstack((self.data['cnt']['data'], cnt)), units='N/A')
-
+            self.data['uct'] = dict(name='Uncertainty Percentage'  , data=np.hstack((self.data['uct']['data'], uct_pct)), units='N/A')
 
         else:
 
@@ -197,7 +202,7 @@ class modis_l1b:
             self.data['rad'] = dict(name='Radiance'                , data=rad, units='W/m^2/nm/sr')
             self.data['ref'] = dict(name='Reflectance (x cos(SZA))', data=ref, units='N/A')
             self.data['cnt'] = dict(name='Corrected Counts'        , data=cnt, units='N/A')
-
+            self.data['uct'] = dict(name='Uncertainty Percentage'  , data=uct_pct, units='N/A')
 
     def save_h5(self, fname):
 
@@ -240,7 +245,6 @@ class modis_l2:
                  extent    = None,  \
                  vnames    = [],    \
                  cop_flag  = '',    \
-                 overwrite = False, \
                  verbose   = False):
 
         self.fnames     = fnames      # file name of the pickle file
@@ -276,7 +280,7 @@ class modis_l2:
         try:
             from pyhdf.SD import SD, SDC
         except ImportError:
-            msg = 'Warning [modis_l1b]: To use \'modis_l1b\', \'pyhdf\' needs to be installed.'
+            msg = 'Warning [modis_l2]: To use \'modis_l2\', \'pyhdf\' needs to be installed.'
             raise ImportError(msg)
 
         if len(cop_flag) == 0:
@@ -326,8 +330,8 @@ class modis_l2:
 
         else:
 
-            lon_range = [self.extent[0]-0.01, self.extent[1]+0.01]
-            lat_range = [self.extent[2]-0.01, self.extent[3]+0.01]
+            lon_range = [self.extent[0], self.extent[1]]
+            lat_range = [self.extent[2], self.extent[3]]
 
         logic     = (lon>=lon_range[0]) & (lon<=lon_range[1]) & (lat>=lat_range[0]) & (lat<=lat_range[1])
         lon       = lon[logic]
@@ -446,6 +450,219 @@ class modis_l2:
 
 
 
+class modis_35_l2:
+
+    """
+    Read MODIS level 2 cloud mask product
+    
+    Note: We currently only support processing of the cloud mask bytes at a 1 km resolution only.
+
+    Input:
+        fnames=   : keyword argument, default=None, Python list of the file path of the original HDF4 file
+        extent=   : keyword argument, default=None, region to be cropped, defined by [westmost, eastmost, southmost, northmost]
+        overwrite=: keyword argument, default=False, whether to overwrite or not
+        verbose=  : keyword argument, default=False, verbose tag
+
+    Output:
+        self.data
+                ['lon']             
+                ['lat']           
+                ['use_qa']          => 0: not useful (discard), 1: useful
+                ['confidence_qa']   => 0: no confidence (do not use), 1: low confidence, 2, ... 7: very high confidence
+                ['cloud_mask_flag'] => 0: not determined, 1: determined
+                ['fov_qa_cat']      => 0: cloudy, 1: uncertain, 2: probably clear, 3: confident clear
+                ['day_night_flag']  => 0: night, 1: day
+                ['sunglint_flag']   => 0: not in sunglint path, 1: in sunglint path
+                ['snow_ice_flag']   => 0: no snow/ice in background, 1: possible snow/ice in background
+                ['land_water_cat']  => 0: water, 1: coastal, 2: desert, 3: land
+                ['lon_5km']        
+                ['lat_5km']
+                
+    References: (Product Page) https://atmosphere-imager.gsfc.nasa.gov/products/cloud-mask
+                (ATBD)         https://atmosphere-imager.gsfc.nasa.gov/sites/default/files/ModAtmo/MOD35_ATBD_Collection6_1.pdf
+                (User Guide)   http://cimss.ssec.wisc.edu/modis/CMUSERSGUIDE.PDF
+    """
+
+
+    ID = 'MODIS Level 2 Cloud Mask Product'
+
+
+    def __init__(self, \
+                 fnames    = None,  \
+                 extent    = None,  \
+                 verbose   = False):
+
+        self.fnames     = fnames      # file name of the pickle file
+        self.extent     = extent      # specified region [westmost, eastmost, southmost, northmost]
+        self.verbose    = verbose     # verbose tag
+
+        for fname in self.fnames:
+            self.read(fname)
+
+    
+    def extract_data(self, data):
+        """
+        Extract cloud mask (in byte format) flags and categories
+        """
+        if data.dtype != 'uint8':
+            data = data.astype('uint8')
+            
+        data = np.unpackbits(data, bitorder='big', axis=1) # convert to binary
+        
+        # extract flags and categories (*_cat) bit by bit
+        land_water_cat  = 2 * data[:, 0] + 1 * data[:, 1] # convert to a value between 0 and 3
+        snow_ice_flag   = data[:, 2]
+        sunglint_flag   = data[:, 3]
+        day_night_flag  = data[:, 4]
+        fov_qa_cat      = 2 * data[:, 5] + 1 * data[:, 6] # convert to a value between 0 and 3
+        cloud_mask_flag = data[:, 7]
+        return cloud_mask_flag, day_night_flag, sunglint_flag, snow_ice_flag, land_water_cat, fov_qa_cat 
+        
+    
+    def quality_assurance(self, data):
+        """
+        Extract cloud mask QA data to determine confidence
+        """
+        if data.dtype != 'uint8':
+            data = data.astype('uint8')
+        
+        # process qa flags
+        data = np.unpackbits(data, bitorder='big', axis=1)
+        confidence_qa = 4 * data[:, 4] + 2 * data[:, 5] + 1 * data[:, 6] # convert to a value between 0 and 7 confidence
+        useful_qa = data[:, 7] # usefulness QA flag
+        return useful_qa, confidence_qa
+        
+        
+    def read(self, fname):
+
+        """
+        Read cloud mask flags and tests/categories
+
+        self.data
+            ['lon']             
+            ['lat']           
+            ['use_qa']          => 0: not useful (discard), 1: useful
+            ['confidence_qa']   => 0: no confidence (do not use), 1: low confidence, 2, ... 7: very high confidence
+            ['cloud_mask_flag'] => 0: not determined, 1: determined
+            ['fov_qa_cat']      => 0: cloudy, 1: uncertain, 2: probably clear, 3: confident clear
+            ['day_night_flag']  => 0: night, 1: day
+            ['sunglint_flag']   => 0: not in sunglint path, 1: in sunglint path
+            ['snow_ice_flag']   => 0: no snow/ice in background, 1: possible snow/ice in background
+            ['land_water_cat']  => 0: water, 1: coastal, 2: desert, 3: land
+            ['lon_5km']        
+            ['lat_5km']
+
+        self.logic
+        self.logic_5km
+        """
+
+        try:
+            from pyhdf.SD import SD, SDC
+        except ImportError:
+            msg = 'Warning [modis_35_l2]: To use \'modis_35_l2\', \'pyhdf\' needs to be installed.'
+            raise ImportError(msg)
+        
+        f          = SD(fname, SDC.READ)
+
+        # lon lat
+        lat0       = f.select('Latitude')
+        lon0       = f.select('Longitude')
+        cld_msk0   = f.select('Cloud_Mask')
+        qa0        = f.select('Quality_Assurance')
+        
+
+        # 1. If region (extent=) is specified, filter data within the specified region
+        # 2. If region (extent=) is not specified, filter invalid data
+        # +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+        lon, lat  = upscale_modis_lonlat(lon0[:], lat0[:], scale=5, extra_grid=True)
+
+        if self.extent is None:
+
+            if 'actual_range' in lon0.attributes().keys():
+                lon_range = lon0.attributes()['actual_range']
+                lat_range = lat0.attributes()['actual_range']
+            elif 'valid_range' in lon0.attributes().keys():
+                lon_range = lon0.attributes()['valid_range']
+                lat_range = lat0.attributes()['valid_range']
+            else:
+                lon_range = [-180.0, 180.0]
+                lat_range = [-90.0 , 90.0]
+
+        else:
+
+            lon_range = [self.extent[0], self.extent[1]]
+            lat_range = [self.extent[2], self.extent[3]]
+
+        logic     = (lon>=lon_range[0]) & (lon<=lon_range[1]) & (lat>=lat_range[0]) & (lat<=lat_range[1])
+        lon       = lon[logic]
+        lat       = lat[logic]
+
+        lon_5km   = lon0[:]
+        lat_5km   = lat0[:]
+        logic_5km = (lon_5km>=lon_range[0]) & (lon_5km<=lon_range[1]) & (lat_5km>=lat_range[0]) & (lat_5km<=lat_range[1])
+        lon_5km   = lon_5km[logic_5km]
+        lat_5km   = lat_5km[logic_5km]
+        
+        
+        # -------------------------------------------------------------------------------------------------
+
+        # Get cloud mask and flag fields 
+        # +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+        cm0_data = get_data_h4(cld_msk0)
+        qa0_data = get_data_h4(qa0)
+        cm = cm0_data.copy()
+        qa = qa0_data.copy()
+        
+        cm = cm[0, :, :] # read only the first of 6 bytes; rest will be supported in the future if needed
+        cm = np.array(cm[logic], dtype='uint8')
+        cm = cm.reshape((cm.size, 1))
+        cloud_mask_flag, day_night_flag, sunglint_flag, snow_ice_flag, land_water_cat, fov_qa_cat = self.extract_data(cm)
+        
+        qa = qa[:, :, 0] # read only the first byte for confidence (indexed differently from cloud mask sds)
+        qa = np.array(qa[logic], dtype='uint8')
+        qa = qa.reshape((qa.size, 1))
+        use_qa, confidence_qa = self.quality_assurance(qa)
+        
+        f.end()
+        # -------------------------------------------------------------------------------------------------
+
+        if hasattr(self, 'data'):
+
+            self.logic[fname] = {'1km':logic, '5km':logic_5km}
+
+            self.data['lon']               = dict(name='Longitude',            data=np.hstack((self.data['lon']['data'], lon)),                         units='degrees')
+            self.data['lat']               = dict(name='Latitude',             data=np.hstack((self.data['lat']['data'], lat)),                         units='degrees')
+            self.data['use_qa']            = dict(name='QA useful',            data=np.hstack((self.data['use_qa']['data'], use_qa)),                   units='N/A')
+            self.data['confidence_qa']     = dict(name='QA Mask confidence',   data=np.hstack((self.data['confidence_qa']['data'], confidence_qa)),     units='N/A')
+            self.data['cloud_mask_flag']   = dict(name='Cloud mask flag',      data=np.hstack((self.data['cloud_mask_flag']['data'], cloud_mask_flag)), units='N/A')
+            self.data['fov_qa_cat']        = dict(name='FOV quality cateogry', data=np.hstack((self.data['fov_qa_cat']['data'], fov_qa_cat)),           units='N/A')
+            self.data['day_night_flag']    = dict(name='Day/night flag',       data=np.hstack((self.data['day_night_flag']['data'], day_night_flag)),   units='N/A')
+            self.data['sunglint_flag']     = dict(name='Sunglint flag',        data=np.hstack((self.data['sunglint_flag']['data'], sunglint_flag)),     units='N/A')
+            self.data['snow_ice_flag']     = dict(name='Snow/ice flag',        data=np.hstack((self.data['snow_flag']['data'], snow_ice_flag)),         units='N/A')
+            self.data['land_water_cat']    = dict(name='Land/water flag',      data=np.hstack((self.data['land_water_cat']['data'], land_water_cat)),   units='N/A')
+            self.data['lon_5km']           = dict(name='Longitude at 5km',     data=np.hstack((self.data['lon_5km']['data'], lon_5km)),                 units='degrees')
+            self.data['lat_5km']           = dict(name='Latitude at 5km',      data=np.hstack((self.data['lat_5km']['data'], lat_5km)),                 units='degrees')
+
+        else:
+            self.logic = {}
+            self.logic[fname] = {'1km':logic, '5km':logic_5km}
+
+            self.data  = {}
+            self.data['lon']             = dict(name='Longitude',            data=lon,             units='degrees')
+            self.data['lat']             = dict(name='Latitude',             data=lat,             units='degrees')
+            self.data['use_qa']          = dict(name='QA useful',            data=use_qa,          units='N/A')         
+            self.data['confidence_qa']   = dict(name='QA Mask confidence',   data=confidence_qa,   units='N/A')
+            self.data['cloud_mask_flag'] = dict(name='Cloud mask flag',      data=cloud_mask_flag, units='N/A')
+            self.data['fov_qa_cat']      = dict(name='FOV quality category', data=fov_qa_cat,      units='N/A')
+            self.data['day_night_flag']  = dict(name='Day/night flag',       data=day_night_flag,  units='N/A')
+            self.data['sunglint_flag']   = dict(name='Sunglint flag',        data=sunglint_flag,   units='N/A')
+            self.data['snow_ice_flag']   = dict(name='Snow/ice flag',        data=snow_ice_flag,   units='N/A')
+            self.data['land_water_cat']  = dict(name='Land/water category',  data=land_water_cat,  units='N/A')
+            self.data['lon_5km']         = dict(name='Longitude at 5km',     data=lon_5km,         units='degrees')
+            self.data['lat_5km']         = dict(name='Latitude at 5km',      data=lat_5km,         units='degrees')
+
+
+
 class modis_03:
 
     """
@@ -545,8 +762,8 @@ class modis_03:
 
         else:
 
-            lon_range = [self.extent[0]-0.01, self.extent[1]+0.01]
-            lat_range = [self.extent[2]-0.01, self.extent[3]+0.01]
+            lon_range = [self.extent[0], self.extent[1]]
+            lat_range = [self.extent[2], self.extent[3]]
 
         logic     = (lon>=lon_range[0]) & (lon<=lon_range[1]) & (lat>=lat_range[0]) & (lat<=lat_range[1])
         lon       = lon[logic]
@@ -693,8 +910,8 @@ class modis_09a1:
             lon_range = [-180.0, 180.0]
             lat_range = [-90.0 , 90.0]
         else:
-            lon_range = [self.extent[0]-0.01, self.extent[1]+0.01]
-            lat_range = [self.extent[2]-0.01, self.extent[3]+0.01]
+            lon_range = [self.extent[0], self.extent[1]]
+            lat_range = [self.extent[2], self.extent[3]]
 
         lon   = LonLat[..., 0]
         lat   = LonLat[..., 1]
@@ -821,8 +1038,8 @@ class modis_43a3:
             lon_range = [-180.0, 180.0]
             lat_range = [-90.0 , 90.0]
         else:
-            lon_range = [self.extent[0]-0.01, self.extent[1]+0.01]
-            lat_range = [self.extent[2]-0.01, self.extent[3]+0.01]
+            lon_range = [self.extent[0], self.extent[1]]
+            lat_range = [self.extent[2], self.extent[3]]
 
         lon   = LonLat[..., 0]
         lat   = LonLat[..., 1]
@@ -1436,20 +1653,6 @@ def get_sinusoidal_grid_tag(lon, lat, verbose=False):
                 tile_tags.append(tile_tag)
 
     return tile_tags
-
-
-
-def find_fname_match(fname0, fnames, index_s=1, index_e=3):
-
-    filename0 = os.path.basename(fname0)
-    pattern  = '.'.join(filename0.split('.')[index_s:index_e+1])
-
-    fname_match = None
-    for fname in fnames:
-        if pattern in fname:
-            fname_match = fname
-
-    return fname_match
 
 #\-----------------------------------------------------------------------------/
 

--- a/er3t/util/util.py
+++ b/er3t/util/util.py
@@ -930,7 +930,7 @@ def download_laads_https(
         try:
             webpage  = urllib.request.urlopen('%s.csv' % fdir_server)
         except urllib.error.HTTPError:
-            msg = '\nError [download_laads_https]: cannot access <%s>.' % fname_server
+            msg = '\nError [download_laads_https]: cannot access <%s>.' % fdir_server
             raise OSError(msg)
     content  = webpage.read().decode('utf-8')
     lines    = content.split('\n')


### PR DESCRIPTION
This PR does the following, all for the same file: `er3t/util/modis.py`:

1. Adds an uncertainty calculation from the L1B product files. This is calculated using the formula provided in the [user guide (section 5.7)](https://mcst.gsfc.nasa.gov/sites/default/files/file_attachments/M1054E_PUG_2017_0901_V6.2.2_Terra_V6.2.1_Aqua.pdf).
2. Bug fixes for `35_l2` reader
3. Other minor appearance and commenting changes