### PR TITLE
Add VIIRS, VIIRS-NRT, MODIS-NRT support to EaR3T

### DIFF
--- a/bin/sdown
+++ b/bin/sdown
@@ -4,7 +4,7 @@
 Downloads satellite data products for any user-specified date and geolocation (lat/lon).
 
 Now supports:
-    MODIS data: MOD-RGB,  MYD-RGB
+    MODIS data: MODRGB,   MYDRGB
                 MOD03,    MYD03
                 MOD02QKM, MYD02QKM
                 MOD02HKM, MYD02HKM
@@ -12,8 +12,15 @@ Now supports:
                 MOD06_L2, MYD06_L2
                 MOD35_L2, MYD35_L2
                 MCD43
-    VIIRS data: ...
-    OCO-2 data: ...
+    
+    VIIRS data: VNPRGB,         VJ1RGB
+                VNP03IMG,       VJ103IMG
+                VNP02IMG,       VJ102IMG
+                VNP03MOD,       VJ103MOD
+                VNP02MOD,       VJ102MOD
+                VNP_CLDPROP_L2, VNP_CLDPROP_L2
+    
+    OCO-2 data: coming soon...
 
 This is a functionality of EaR3T.
 
@@ -23,7 +30,7 @@ Authors:
 
 Example Usage:
     sdown --date 20210523 --lons 30 35 --lats 0 10 --products mod06_l2 --fdir sat-data/ --verbose
-    sdown --date 20130714 --extent 30 35 0 10 --products modrgb myd02hkm myd06_l2 --fdir sat-data/
+    sdown --date 20130714 --extent 30 35 0 10 --products modrgb vnp02img --fdir sat-data/
 
 To see a demonstration of how this tool works, use:
     sdown --run_demo
@@ -213,20 +220,20 @@ _sat_tags_support_ = {
                 'dataset_tag': '5200/VNP02IMG',
                    'dict_key': 'vnp_02',
                 'description': 'Suomi-NPP VIIRS Level 1b (375m) Calibrated Radiances Product',
-                    'website': 'placeholder',
+                    'website': 'https://doi.org/10.5067/VIIRS/VNP02IMG.002',
                   'satellite': 'SNPP',
                  'instrument': 'VIIRS',
-                  'reference': 'placeholder',
+                  'reference': 'VCST Team. 2016-09-01. VIIRS/NPP Imagery Resolution 6-Min L1B Swath 375m. Version 1. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VNP02IMG.001',
                 },
         
         'VJ102IMG': {
                 'dataset_tag': '5200/VJ102IMG',
                    'dict_key': 'vj1_02',
                 'description': 'JPSS1 (NOAA-20) VIIRS Level 1b (375m) Calibrated Radiances Product',
-                    'website': 'placeholder',
+                    'website': 'https://doi.org/10.5067/VIIRS/VJ102IMG.021',
                   'satellite': 'NOAA20',
                  'instrument': 'VIIRS',
-                  'reference': 'placeholder',
+                  'reference': 'VCST Team. 2019-08-01. VIIRS/JPSS1 Imagery Resolution 6-Min L1B Swath 375m. Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VJ102IMG.002',
                 },
 
 
@@ -234,87 +241,87 @@ _sat_tags_support_ = {
                 'dataset_tag': '5200/VNP02MOD',
                    'dict_key': 'vnp_02',
                 'description': 'Suomi-NPP VIIRS Level 1b (750m) Calibrated Radiances Product',
-                    'website': 'placeholder',
+                    'website': 'https://doi.org/10.5067/VIIRS/VNP02MOD.002',
                   'satellite': 'SNPP',
                  'instrument': 'VIIRS',
-                  'reference': 'placeholder',
+                  'reference': 'VCST Team. 2021-07-12. VIIRS/NPP Moderate Resolution Terrain Corrected Geolocation 6-Min L1 Swath 750 m . Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VNP02MOD.002.',
                 },
         
         'VJ102MOD': {
                 'dataset_tag': '5200/VJ102MOD',
                    'dict_key': 'vj1_02',
                 'description': 'JPSS1 (NOAA-20) VIIRS Level 1b (750m) Calibrated Radiances Product',
-                    'website': 'placeholder',
+                    'website': 'https://doi.org/10.5067/VIIRS/VJ102MOD.021',
                   'satellite': 'NOAA20',
                  'instrument': 'VIIRS',
-                  'reference': 'placeholder',
+                  'reference': 'VCST Team. 2019-08-01. VIIRS/JPSS1 Moderate Resolution 6-Min L1B Swath 750m. Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VJ102MOD.002',
                 },
 
         'VNP03IMG': {
                 'dataset_tag': '5200/VNP03IMG',
                    'dict_key': 'vnp_03',
                 'description': 'Suomi-NPP VIIRS (375m) Geolocation Fields Product',
-                    'website': 'placeholder',
+                    'website': 'https://doi.org/10.5067/VIIRS/VNP03IMG.002',
                   'satellite': 'SNPP',
                  'instrument': 'VIIRS',
-                  'reference': 'placeholder',
+                  'reference': 'VCST Team. VIIRS/NPP Imagery Resolution Terrain-Corrected Geolocation 6-Min L1 Swath 375m Light. Version 1. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VNP03IMGLL.001',
                 },
         
         'VJ103IMG': {
                 'dataset_tag': '5200/VJ103IMG',
                    'dict_key': 'vj1_03',
                 'description': 'JPSS1 (NOAA-20) VIIRS (375m) Geolocation Fields Product',
-                    'website': 'placeholder',
+                    'website': 'https://doi.org/10.5067/VIIRS/VJ103IMG.021',
                   'satellite': 'NOAA20',
                  'instrument': 'VIIRS',
-                  'reference': 'placeholder',
+                  'reference': 'VCST Team. VIIRS/JPSS1 Imagery Resolution Terrain-Corrected Geolocation 6-Min L1 Swath 375m Light. Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VJ103IMG.021',
                 },
             
         'VNP03MOD': {
                 'dataset_tag': '5200/VNP03MOD',
                    'dict_key': 'vnp_03',
                 'description': 'Suomi-NPP VIIRS (750m) Geolocation Fields Product',
-                    'website': 'placeholder',
+                    'website': 'https://doi.org/10.5067/VIIRS/VNP03MOD.002',
                   'satellite': 'SNPP',
                  'instrument': 'VIIRS',
-                  'reference': 'placeholder',
+                  'reference': 'VCST Team. 2021-07-12. VIIRS/NPP Moderate Resolution Terrain-Corrected Geolocation L1 6-Min Swath 750 m. Version 2. LAADS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VNP03MOD.002',
                 },
         
         'VJ103MOD': {
                 'dataset_tag': '5200/VJ103MOD',
                    'dict_key': 'vj1_03',
                 'description': 'JPSS1 (NOAA-20) VIIRS (750m) Geolocation Fields Product',
-                    'website': 'placeholder',
+                    'website': 'https://doi.org/10.5067/VIIRS/VJ103MOD.021',
                   'satellite': 'NOAA20',
                  'instrument': 'VIIRS',
-                  'reference': 'placeholder',
+                  'reference': 'VCST Team. 2019-08-01. VIIRS/JPSS1 Moderate Resolution Terrain Corrected Geolocation 6-Min L1 Swath 750m. Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VJ103MOD.002',
                 },
 
         'VNPRGB': {
                 'dataset_tag': '5200/VNPRGB',
                    'dict_key': 'vnp_rgb',
                 'description': 'Suomi-NPP VIIRS True Color (RGB) Imagery',
-                    'website': 'placeholder',
+                    'website': 'https://worldview.earthdata.nasa.gov',
                   'satellite': 'SNPP',
                  'instrument': 'VIIRS',
-                  'reference': 'placeholder',
+                  'reference': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
                 },
         
         'VJ1RGB': {
                 'dataset_tag': '5200/VJ1RGB',
                    'dict_key': 'vj1_rgb',
                 'description': 'JPSS1 (NOAA-20) VIIRS True Color (RGB) Imagery',
-                    'website': 'placeholder',
+                    'website': 'https://worldview.earthdata.nasa.gov',
                   'satellite': 'NOAA20',
                  'instrument': 'VIIRS',
-                  'reference': 'placeholder',
+                  'reference': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
                 },
 
         'VNP_CLDPROP_L2': {
                 'dataset_tag': '5111/CLDPROP_L2_VIIRS_SNPP',
                    'dict_key': 'vnp_l2',
                 'description': 'Suomi-NPP VIIRS Cloud Properties Product',
-                    'website': 'placeholder',
+                    'website': 'https://doi.org/10.5067/VIIRS/CLDPROP_L2_VIIRS_SNPP.011',
                   'satellite': 'SNPP',
                  'instrument': 'VIIRS',
                   'reference': 'placeholder',
@@ -324,7 +331,7 @@ _sat_tags_support_ = {
                 'dataset_tag': '5111/CLDPROP_L2_VIIRS_NOAA20',
                    'dict_key': 'vj1_l2',
                 'description': 'JPSS1 (NOAA-20) VIIRS Cloud Properties Product',
-                    'website': 'placeholder',
+                    'website': 'https://ladsweb.modaps.eosdis.nasa.gov/missions-and-measurements/products/CLDPROP_L2_VIIRS_NOAA20',
                   'satellite': 'NOAA20',
                  'instrument': 'VIIRS',
                   'reference': 'placeholder',
@@ -447,9 +454,10 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
             if not os.path.exists(fdir_out_dt):
                 os.makedirs(fdir_out_dt)
 
+            # Save metadata
             with open(os.path.join(fdir_out_dt, "metadata.txt"), "w") as f:
-                f.write("DATE:{}\n".format(date_x))
-                f.write("EXTENT:{}\n".format(extent))
+                f.write('Date: {}\n'.format(date_x))
+                f.write('Extent: {}\n'.format(extent))
 
             print("Obtaining data for: ", date_x, extent)
             run(date_x, extent, fdir_out_dt, nrt, products, verbose)
@@ -632,7 +640,7 @@ if __name__ == '__main__':
                         'MYDRGB  :  True-Color RGB (Aqua)  imagery, useful for visuzliation\n'\
                         'MCD43   :  Level 3 surface product MCD43A3\n'\
                         '\nTo download multiple products at a time:\n'\
-                        '--products MOD021KM MYD02HKM MYD06_l2\n \n')
+                        '--products MOD021KM VJ102MOD MYD06_l2\n \n')
 
     args = parser.parse_args()
 
@@ -644,7 +652,7 @@ if __name__ == '__main__':
         lons       = None
         lats       = None
         fdir       = 'sat-data/'
-        products   = ['MODRGB', 'MYD02QKM']
+        products   = ['MODRGB', 'VNP02IMG']
         nrt        =  False
         verbose    = 1
 

--- a/bin/sdown
+++ b/bin/sdown
@@ -64,6 +64,12 @@ _description_ = '=' * _width_ + '\n\n' + \
 _today_dt    = datetime.datetime.today()
 _date_today_ = _today_dt.strftime('%d %B, %Y')
 
+# Production start dates for error handling
+_aqua_modis_start_date   = datetime.datetime(2002, 7, 4)
+_terra_modis_start_date  = datetime.datetime(2000, 2, 24)
+_snpp_viirs_start_date   = datetime.datetime(2012, 1, 19)
+_noaa20_viirs_start_date = datetime.datetime(2018, 1, 5)
+
 _sat_tags_support_ = {
 
         'MODRGB': {
@@ -374,9 +380,19 @@ _sat_tags_support_ = {
 def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out, nrt, products, verbose):
 
 
-    # Error handling
+    ########################################################################################################
+    ############################################ Error handling ############################################
+    ########################################################################################################
+
     if products is None:
         sys.exit('\nError [sdown]: Please specify a product to download. \nWe currently support the following:\n%s\n' % ('\n'.join(_sat_tags_support_.keys())))
+    else:
+        # separate product ids for error handling
+        modis_aqua   = list(filter(lambda x: x.upper().startswith('MYD'), products))
+        modis_terra  = list(filter(lambda x: x.upper().startswith('MOD'), products))
+        viirs_snpp   = list(filter(lambda x: x.upper().startswith('VNP'), products))
+        viirs_noaa20 = list(filter(lambda x: x.upper().startswith('VJ1'), products))
+
 
     if (extent is None) and ((lats is None) or (lons is None)):
         sys.exit('\nError [sdown]: Must provide either extent or lon/lat coordinates\n')
@@ -411,7 +427,25 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
             msg = '\nError [sdown]: Provided date is in the future. Data will only be downloaded until today\'s date.' + \
                   '\n\nReceived date   : %s\nToday\'s date is : %s\n' % (single_dt.strftime("%d %B, %Y"), _today_dt.strftime("%d %B, %Y"))
             sys.exit(msg)
+        
+        # check if products exist in those date ranges
+        if len(modis_aqua) > 0 and single_dt < _aqua_modis_start_date:
+            msg = '\nError [sdown]: Received %s as date of interest but data for MODIS onboard Aqua only exists from %s. Retry with more recent dates.\n' % (single_dt.strftime("%d %B, %Y"), _aqua_modis_start_date.strftime("%d %B, %Y"))
+            sys.exit(msg)
 
+        if len(modis_terra) > 0 and single_dt < _aqua_terra_start_date:
+            msg = '\nError [sdown]: Received %s as date of interest but data for MODIS onboard Terra only exists from %s. Retry with more recent dates.\n' % (single_dt.strftime("%d %B, %Y"), _terra_modis_start_date.strftime("%d %B, %Y"))
+            sys.exit(msg)
+        
+        if len(viirs_snpp) > 0 and single_dt < _snpp_viirs_start_date:
+            msg = '\nError [sdown]: Received %s as date of interest but data for VIIRS onboard NOAA-20 (SNPP) only exists from %s. Retry with more recent dates.\n' % (single_dt.strftime("%d %B, %Y"), _snpp_viirs_start_date.strftime("%d %B, %Y"))
+            sys.exit(msg)
+
+        if len(viirs_noaa20) > 0 and single_dt < _noaa20_viirs_start_date:
+            msg = '\nError [sdown]: Received %s as date of interest but data for VIIRS onboard NOAA-20 (JPSS1) only exists from %s. Retry with more recent dates.\n' % (single_dt.strftime("%d %B, %Y"), _noaa20_viirs_start_date.strftime("%d %B, %Y"))
+            sys.exit(msg)
+
+        # Passed checks, start download
         if verbose:
             print('\nMessage [sdown]: Data will be downloaded for %s\n' % single_dt.strftime("%d %B, %Y"))
 
@@ -420,8 +454,8 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
             os.makedirs(fdir_out_dt)
 
         with open(os.path.join(fdir_out_dt, "metadata.txt"), "w") as f:
-            f.write("DATE:{}\n".format(single_dt))
-            f.write("EXTENT:{}\n".format(extent))
+            f.write("Date: {}\n".format(single_dt))
+            f.write("Extent: {}\n".format(extent))
 
         run(single_dt, extent, fdir_out_dt, nrt, products, verbose)
 
@@ -444,7 +478,30 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
                   '\n\nReceived end date: %s\nToday\'s date is : %s\n' % (end_dt.strftime("%d %B, %Y"), _today_dt.strftime("%d %B, %Y"))
             print(msg)
             end_dt = _today_dt
+        
 
+        # check if products exist in those date ranges
+        if len(modis_aqua) > 0 and start_dt < _aqua_modis_start_date:
+            msg = '\nError [sdown]: Received %s as starting date of interest but data for MODIS onboard Aqua only exists from %s. Retry with more recent dates.\n' % (start_dt.strftime("%d %B, %Y"), _aqua_modis_start_date.strftime("%d %B, %Y"))
+            sys.exit(msg)
+
+        if len(modis_terra) > 0 and start_dt < _aqua_terra_start_date:
+            msg = '\nError [sdown]: Received %s as starting date of interest but data for MODIS onboard Terra only exists from %s. Retry with more recent dates.\n' % (start_dt.strftime("%d %B, %Y"), _terra_modis_start_date.strftime("%d %B, %Y"))
+            sys.exit(msg)
+
+        if len(viirs_snpp) > 0 and start_dt < _snpp_viirs_start_date:
+            msg = '\nError [sdown]: Received %s as starting date of interest but data for VIIRS onboard NOAA-20 (SNPP) only exists from %s. Retry with more recent dates.\n' % (start_dt.strftime("%d %B, %Y"), _snpp_viirs_start_date.strftime("%d %B, %Y"))
+            sys.exit(msg)
+
+        if len(viirs_noaa20) > 0 and start_dt < _noaa20_viirs_start_date:
+            msg = '\nError [sdown]: Received %s as starting date of interest but data for VIIRS onboard NOAA-20 (JPSS1) only exists from %s. Retry with more recent dates.\n' % (start_dt.strftime("%d %B, %Y"), _noaa20_viirs_start_date.strftime("%d %B, %Y"))
+            sys.exit(msg)
+
+        ########################################################################################################
+        ########################################## End error handling ##########################################
+        ########################################################################################################
+        
+        # Passed checks, start download
         if verbose:
             print('\nMessage [sdown]: Data will be downloaded for dates beginning %s to %s\n' % (start_dt.strftime("%d %B, %Y"), end_dt.strftime("%d %B, %Y")))
 

--- a/bin/sdown
+++ b/bin/sdown
@@ -162,7 +162,7 @@ _sat_tags_support_ = {
         'MOD06_L2': {
                 'dataset_tag': '61/MOD06_L2',
                    'dict_key': 'mod_l2',
-                'description': 'Terra MODIS Atmosphere L2 Cloud Product',
+                'description': 'Terra MODIS Atmosphere Level 2 Cloud Product',
                     'website': 'http://dx.doi.org/10.5067/MODIS/MOD06_L2.061',
                   'satellite': 'Terra',
                  'instrument': 'MODIS',
@@ -172,7 +172,7 @@ _sat_tags_support_ = {
         'MYD06_L2': {
                 'dataset_tag': '61/MYD06_L2',
                    'dict_key': 'myd_l2',
-                'description': 'Aqua MODIS Atmosphere L2 Cloud Product',
+                'description': 'Aqua MODIS Atmosphere Level 2 Cloud Product',
                     'website': 'http://dx.doi.org/10.5067/MODIS/MYD06_L2.061',
                   'satellite': 'Aqua',
                  'instrument': 'MODIS',
@@ -182,7 +182,7 @@ _sat_tags_support_ = {
         'MOD35_L2': {
                 'dataset_tag': '61/MOD35_L2',
                    'dict_key': 'mod_l2',
-                'description': 'Terra MODIS Atmosphere L2 Cloud Mask',
+                'description': 'Terra MODIS Atmosphere Level 2 Cloud Mask',
                     'website': 'http://dx.doi.org/10.5067/MODIS/MOD35_L2.061',
                   'satellite': 'Terra',
                  'instrument': 'MODIS',
@@ -192,7 +192,7 @@ _sat_tags_support_ = {
         'MYD35_L2': {
                 'dataset_tag': '61/MYD35_L2',
                    'dict_key': 'myd_l2',
-                'description': 'Aqua MODIS Atmosphere L2 Cloud Mask',
+                'description': 'Aqua MODIS Atmosphere Level 2 Cloud Mask',
                     'website': 'http://dx.doi.org/10.5067/MODIS/MYD35_L2.061',
                   'satellite': 'Aqua',
                  'instrument': 'MODIS',
@@ -202,7 +202,7 @@ _sat_tags_support_ = {
         'MCD43A3': {
                 'dataset_tag': '61/MCD43A3',
                    'dict_key': 'mod_43',
-                'description': 'MODIS BRDF/Albedo L3 Surface Product',
+                'description': 'MODIS BRDF/Albedo Level 3 Surface Product',
                     'website': 'https://doi.org/10.5067/MODIS/MCD43A3.061',
                   'satellite': 'Terra & Aqua',
                  'instrument': 'MODIS',
@@ -292,7 +292,7 @@ _sat_tags_support_ = {
 
         'VNPRGB': {
                 'dataset_tag': '5200/VNPRGB',
-                   'dict_key': 'vnp_03',
+                   'dict_key': 'vnp_rgb',
                 'description': 'Suomi-NPP VIIRS True Color (RGB) Imagery',
                     'website': 'placeholder',
                   'satellite': 'SNPP',
@@ -302,8 +302,28 @@ _sat_tags_support_ = {
         
         'VJ1RGB': {
                 'dataset_tag': '5200/VJ1RGB',
-                   'dict_key': 'vj1_03',
+                   'dict_key': 'vj1_rgb',
                 'description': 'JPSS1 (NOAA-20) VIIRS True Color (RGB) Imagery',
+                    'website': 'placeholder',
+                  'satellite': 'NOAA20',
+                 'instrument': 'VIIRS',
+                  'reference': 'placeholder',
+                },
+
+        'VNP_CLDPROP_L2': {
+                'dataset_tag': '5111/CLDPROP_L2_VIIRS_SNPP',
+                   'dict_key': 'vnp_l2',
+                'description': 'Suomi-NPP VIIRS Cloud Properties Product',
+                    'website': 'placeholder',
+                  'satellite': 'SNPP',
+                 'instrument': 'VIIRS',
+                  'reference': 'placeholder',
+                },
+
+        'VJ1_CLDPROP_L2': {
+                'dataset_tag': '5111/CLDPROP_L2_VIIRS_NOAA20',
+                   'dict_key': 'vj1_l2',
+                'description': 'JPSS1 (NOAA-20) VIIRS Cloud Properties Product',
                     'website': 'placeholder',
                   'satellite': 'NOAA20',
                  'instrument': 'VIIRS',

--- a/bin/sdown
+++ b/bin/sdown
@@ -209,6 +209,107 @@ _sat_tags_support_ = {
                   'reference': 'Schaaf, C., and Wang, Z.: MODIS/Terra+Aqua BRDF/Albedo Daily L3 Global - 500m V061, NASA EOSDIS Land Processes DAAC [data set], https://doi.org/10.5067/MODIS/MCD43A3.061 (last access: %s), 2021.' % _date_today_,
                 },
 
+        'VNP02IMG': {
+                'dataset_tag': '5200/VNP02IMG',
+                   'dict_key': 'vnp_02',
+                'description': 'Suomi-NPP VIIRS Level 1b (375m) Calibrated Radiances Product',
+                    'website': 'placeholder',
+                  'satellite': 'SNPP',
+                 'instrument': 'VIIRS',
+                  'reference': 'placeholder',
+                },
+        
+        'VJ102IMG': {
+                'dataset_tag': '5200/VJ102IMG',
+                   'dict_key': 'vj1_02',
+                'description': 'JPSS1 (NOAA-20) VIIRS Level 1b (375m) Calibrated Radiances Product',
+                    'website': 'placeholder',
+                  'satellite': 'NOAA20',
+                 'instrument': 'VIIRS',
+                  'reference': 'placeholder',
+                },
+
+
+        'VNP02MOD': {
+                'dataset_tag': '5200/VNP02MOD',
+                   'dict_key': 'vnp_02',
+                'description': 'Suomi-NPP VIIRS Level 1b (750m) Calibrated Radiances Product',
+                    'website': 'placeholder',
+                  'satellite': 'SNPP',
+                 'instrument': 'VIIRS',
+                  'reference': 'placeholder',
+                },
+        
+        'VJ102MOD': {
+                'dataset_tag': '5200/VJ102MOD',
+                   'dict_key': 'vj1_02',
+                'description': 'JPSS1 (NOAA-20) VIIRS Level 1b (750m) Calibrated Radiances Product',
+                    'website': 'placeholder',
+                  'satellite': 'NOAA20',
+                 'instrument': 'VIIRS',
+                  'reference': 'placeholder',
+                },
+
+        'VNP03IMG': {
+                'dataset_tag': '5200/VNP03IMG',
+                   'dict_key': 'vnp_03',
+                'description': 'Suomi-NPP VIIRS (375m) Geolocation Fields Product',
+                    'website': 'placeholder',
+                  'satellite': 'SNPP',
+                 'instrument': 'VIIRS',
+                  'reference': 'placeholder',
+                },
+        
+        'VJ103IMG': {
+                'dataset_tag': '5200/VJ103IMG',
+                   'dict_key': 'vj1_03',
+                'description': 'JPSS1 (NOAA-20) VIIRS (375m) Geolocation Fields Product',
+                    'website': 'placeholder',
+                  'satellite': 'NOAA20',
+                 'instrument': 'VIIRS',
+                  'reference': 'placeholder',
+                },
+            
+        'VNP03MOD': {
+                'dataset_tag': '5200/VNP03MOD',
+                   'dict_key': 'vnp_03',
+                'description': 'Suomi-NPP VIIRS (750m) Geolocation Fields Product',
+                    'website': 'placeholder',
+                  'satellite': 'SNPP',
+                 'instrument': 'VIIRS',
+                  'reference': 'placeholder',
+                },
+        
+        'VJ103MOD': {
+                'dataset_tag': '5200/VJ103MOD',
+                   'dict_key': 'vj1_03',
+                'description': 'JPSS1 (NOAA-20) VIIRS (750m) Geolocation Fields Product',
+                    'website': 'placeholder',
+                  'satellite': 'NOAA20',
+                 'instrument': 'VIIRS',
+                  'reference': 'placeholder',
+                },
+
+        'VNPRGB': {
+                'dataset_tag': '5200/VNPRGB',
+                   'dict_key': 'vnp_03',
+                'description': 'Suomi-NPP VIIRS True Color (RGB) Imagery',
+                    'website': 'placeholder',
+                  'satellite': 'SNPP',
+                 'instrument': 'VIIRS',
+                  'reference': 'placeholder',
+                },
+        
+        'VJ1RGB': {
+                'dataset_tag': '5200/VJ1RGB',
+                   'dict_key': 'vj1_03',
+                'description': 'JPSS1 (NOAA-20) VIIRS True Color (RGB) Imagery',
+                    'website': 'placeholder',
+                  'satellite': 'NOAA20',
+                 'instrument': 'VIIRS',
+                  'reference': 'placeholder',
+                },
+
         'oco2_L1bScND': {
                 'dataset_tag': 'oco2_L1bScND',
                    'dict_key': 'oco_l1b',
@@ -243,7 +344,7 @@ _sat_tags_support_ = {
 #\----------------------------------------------------------------------------/#
 
 
-def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out, products, verbose):
+def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out, nrt, products, verbose):
 
 
     # Error handling
@@ -259,7 +360,7 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
     elif (extent is None) and (lats is not None) and (lons is not None) and ((len(lats) == 2) and (len(lons) == 2)) and (lons[0] < lons[1]) and (lats[0] < lats[1]):
         extent = [lons[0], lons[1], lats[0], lats[1]]
 
-    
+
     # check to make sure extent is correct
     if (extent[0] >= extent[1]) or (extent[2] >= extent[3]):
         msg = '\nError [sdown]: The given extents of lon/lat are incorrect: %s.\nPlease check to make sure extent is passed as `lon1 lon2 lat1 lat2` format i.e. West, East, South, North.\n' % extent
@@ -276,7 +377,7 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
         sys.exit('\nError [sdown]: Please provide a date via --date or date range via --start_date and --end_date\n')
 
     elif (date is not None) and ((start_date is None) or (end_date is None)):
-        
+
         single_dt = datetime.datetime(int(date[:4]), int(date[4:6]), int(date[6:8]))
 
         if (datetime.timedelta((_today_dt - single_dt).days).days < 0):
@@ -286,12 +387,16 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
 
         if verbose:
             print('\nMessage [sdown]: Data will be downloaded for %s\n' % single_dt.strftime("%d %B, %Y"))
-        
+
         fdir_out_dt = os.path.join(fdir_out, single_dt.strftime('%Y_%m_%d')) # save files in dirs with dates specified
         if not os.path.exists(fdir_out_dt):
             os.makedirs(fdir_out_dt)
-        
-        run(single_dt, extent, fdir_out_dt, products, verbose)
+
+        with open(os.path.join(fdir_out_dt, "metadata.txt"), "w") as f:
+            f.write("DATE:{}\n".format(single_dt))
+            f.write("EXTENT:{}\n".format(extent))
+
+        run(single_dt, extent, fdir_out_dt, nrt, products, verbose)
 
     elif (start_date is not None) and (end_date is not None):
 
@@ -301,7 +406,7 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
             msg = '\nError [sdown]: `end_date` must be on or after `start_date`.' + \
                   '\n\nReceived start date: %s\nReceived end date: %s\n' % (start_dt.strftime("%d %B, %Y"), end_dt.strftime("%d %B, %Y"))
             sys.exit(msg)
-        
+
         if (datetime.timedelta((_today_dt - start_dt).days).days < 0):
             msg = '\nError [sdown]: `start_date` cannot be in the future.' + \
                   '\n\nReceived start date: %s\nToday\'s date is    : %s\n' % (start_dt.strftime("%d %B, %Y"), _today_dt.strftime("%d %B, %Y"))
@@ -315,18 +420,24 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
 
         if verbose:
             print('\nMessage [sdown]: Data will be downloaded for dates beginning %s to %s\n' % (start_dt.strftime("%d %B, %Y"), end_dt.strftime("%d %B, %Y")))
-        
+
         date_list = [start_dt + datetime.timedelta(days=x) for x in range((end_dt - start_dt).days + 1)]
         for date_x in date_list: # download products date by date
             fdir_out_dt = os.path.join(fdir_out, date_x.strftime('%Y_%m_%d')) # save files in dirs with dates specified
             if not os.path.exists(fdir_out_dt):
                 os.makedirs(fdir_out_dt)
-            run(date_x, extent, fdir_out_dt, products, verbose)
+
+            with open(os.path.join(fdir_out_dt, "metadata.txt"), "w") as f:
+                f.write("DATE:{}\n".format(date_x))
+                f.write("EXTENT:{}\n".format(extent))
+
+            print("Obtaining data for: ", date_x, extent)
+            run(date_x, extent, fdir_out_dt, nrt, products, verbose)
 
 
 
 
-def run(date, extent, fdir_out, products, verbose):
+def run(date, extent, fdir_out, nrt, products, verbose):
 
     lon0 = np.linspace(extent[0], extent[1], 100)
     lat0 = np.linspace(extent[2], extent[3], 100)
@@ -366,24 +477,51 @@ def run(date, extent, fdir_out, products, verbose):
                 fnames[product_info['dict_key']] += p_fnames
 
         # MODIS Level-1b radiances, Level-2 cloud products, and solar/viewing geoemetries
-        elif product.upper().endswith(('QKM', 'HKM', '1KM', 'L2', '03')):
-            filename_tags_03 = er3t.util.get_satfile_tag(date=date,
+        elif product.upper().endswith(('QKM', 'HKM', '1KM', 'L2', '03', '02IMG', '02MOD', '03IMG', '03MOD')):
+            if nrt:
+                link_to_nrt = 'https://www.earthdata.nasa.gov/learn/find-data/near-real-time/near-real-time-versus-standard-products'
+                msg = 'Warning [sdown]: Downloading Near Real Time (NRT) products. \n'\
+                      'Please note that the standard product processing rules are relaxed to allow '\
+                      'for faster generation of products and therefore may not be the same quality. '\
+                      'For a complete breakdown of how NASA generates these NRT products, visit:\n'\
+                      ' %s\n\n' % link_to_nrt
+                print(msg)
+
+                filename_tags_03 = er3t.util.get_nrt_satfile_tag(date=date,
+                                                                lon=lon,
+                                                                lat=lat,
+                                                                satellite=product_info['satellite'],
+                                                                instrument=product_info['instrument'],
+                                                                verbose=verbose)
+                
+                if verbose:
+                    print('Message [sdown]: Found %s %s overpasses for %s\n' % (len(filename_tags_03), product_info['satellite'], date.strftime('%B %d, %Y')))
+
+                for filename_tag in filename_tags_03:
+                    p_fnames = er3t.util.download_lance_https(date=date,
+                                                            dataset_tag=product_info['dataset_tag'],
+                                                            filename_tag=filename_tag,
+                                                            day_interval=1,
+                                                            fdir_out=fdir_out,
+                                                            verbose=verbose)
+            else:
+                filename_tags_03 = er3t.util.get_satfile_tag(date=date,
                                                          lon=lon,
                                                          lat=lat,
                                                          satellite=product_info['satellite'],
                                                          instrument=product_info['instrument'],
                                                          verbose=verbose)
-            if verbose:
-                print('Message [sdown]: Found %s %s overpasses for %s\n' % (len(filename_tags_03), product_info['satellite'], date.strftime('%B %d, %Y')))
+                if verbose:
+                    print('Message [sdown]: Found %s %s overpasses for %s\n' % (len(filename_tags_03), product_info['satellite'], date.strftime('%B %d, %Y')))
 
-            for filename_tag in filename_tags_03:
-                p_fnames = er3t.util.download_laads_https(date=date,
-                                                          dataset_tag=product_info['dataset_tag'],
-                                                          filename_tag=filename_tag,
-                                                          day_interval=1,
-                                                          fdir_out=fdir_out,
-                                                          verbose=verbose)
-                fnames[product_info['dict_key']] += p_fnames
+                for filename_tag in filename_tags_03:
+                    p_fnames = er3t.util.download_laads_https(date=date,
+                                                            dataset_tag=product_info['dataset_tag'],
+                                                            filename_tag=filename_tag,
+                                                            day_interval=1,
+                                                            fdir_out=fdir_out,
+                                                            verbose=verbose)
+            fnames[product_info['dict_key']] += p_fnames
 
         else:
             msg = '\nError [sdown]: Cannot recognize satellite product from the given tag <%s>, abort...\nCurrently, only the following satellite products are supported by <sdown>:\n%s' % (product, '\n'.join(_sat_tags_support_.keys()))
@@ -450,6 +588,10 @@ if __name__ == '__main__':
     required.add_argument('-y', '--lats', nargs='+', type=float, metavar='',
                         help='The south-most and north-most latitudes of the region.\nAlternative to providing the last two terms in `extent`.\n'\
                         'Example:  --lats 25 30\n \n')
+    required.add_argument('-n', '--nrt', action='store_true',
+                        help='Pass --nrt if Near Real Time products should be downloaded.\n'\
+                             'This is disabled by default to automatically download standard products.\n'\
+                             'Currently, only MODIS NRT products can be downloaded.\n')
     required.add_argument('-p', '--products', type=str, nargs='+', metavar='',
                         help='Short prefix (case insensitive) for the product name.\n'\
                         'Example:  --products MOD02QKM\n'
@@ -483,6 +625,7 @@ if __name__ == '__main__':
         lats       = None
         fdir       = 'sat-data/'
         products   = ['MODRGB', 'MYD02QKM']
+        nrt        =  False
         verbose    = 1
 
         sat0 = satellite_download(date=date,
@@ -492,6 +635,7 @@ if __name__ == '__main__':
                                   lons=lons,
                                   lats=lats,
                                   fdir_out=fdir,
+                                  nrt=nrt,
                                   products=products,
                                   verbose=verbose)
     else:
@@ -502,5 +646,6 @@ if __name__ == '__main__':
                                   lons=args.lons,
                                   lats=args.lats,
                                   fdir_out=args.fdir,
+                                  nrt=args.nrt,
                                   products=args.products,
                                   verbose=args.verbose)

--- a/er3t/util/util.py
+++ b/er3t/util/util.py
@@ -19,7 +19,7 @@ __all__ = ['all_files', 'check_equal', 'check_equidistant', 'send_email', \
            'get_data_nc', 'get_data_h4', \
            'find_nearest', 'move_correlate', \
            'grid_by_extent', 'grid_by_lonlat', 'grid_by_dxdy', \
-           'get_doy_tag', 'get_satfile_tag', \
+           'get_doy_tag', 'get_satfile_tag', 'get_nrt_satfile_tag', \
            'download_laads_https', 'download_lance_https', 'download_worldview_rgb'] + \
           ['combine_alt', 'get_lay_index', 'downscale', 'upscale_2d', 'mmr2vmr', \
            'cal_rho_air', 'cal_sol_fac', 'cal_mol_ext', 'cal_ext', \
@@ -270,7 +270,7 @@ def get_data_h4(hdf_dset):
 
 
 def move_correlate(data0, data, Ndx=5, Ndy=5):
-    
+
     try:
         from scipy import stats
     except ImportError:
@@ -335,7 +335,7 @@ def find_nearest(x_raw, y_raw, data_raw, x_out, y_out, Ngrid_limit=1, fill_value
     Output:
         data_out: gridded data
     """
-    
+
     try:
         from scipy.spatial import KDTree
     except ImportError:
@@ -428,7 +428,7 @@ def grid_by_extent(lon, lat, data, extent=None, NxNy=None, method='nearest', fil
         After read in the longitude latitude and data into lon0, lat0, data0
         lon, lat, data = grid_by_extent(lon0, lat0, data0, extent=[10, 15, 10, 20])
     """
-    
+
     try:
         from scipy import interpolate
     except ImportError:
@@ -499,7 +499,7 @@ def grid_by_lonlat(lon, lat, data, lon_1d=None, lat_1d=None, method='nearest', f
         After read in the longitude latitude and data into lon0, lat0, data0
         lon, lat, data = grid_by_lonlat(lon0, lat0, data0, lon_1d=np.linspace(10.0, 15.0, 100), lat_1d=np.linspace(10.0, 20.0, 100))
     """
-    
+
     try:
         from scipy import interpolate
     except ImportError:
@@ -569,7 +569,7 @@ def grid_by_dxdy(lon, lat, data, extent=None, dx=None, dy=None, method='nearest'
         After read in the longitude latitude and data into lon0, lat0, data0
         lon, lat, data = grid_by_dxdy(lon0, lat0, data0, dx=250.0, dy=250.0)
     """
-    
+
     try:
         from scipy import interpolate
     except ImportError:
@@ -763,6 +763,238 @@ def get_satfile_tag(
     fnames_server = {
         'Aqua|MODIS'  : '%s/archive/geoMeta/61/AQUA/%4.4d/MYD03_%s.txt'           % (server, date.year, date_s),
         'Terra|MODIS' : '%s/archive/geoMeta/61/TERRA/%4.4d/MOD03_%s.txt'          % (server, date.year, date_s),
+        'NOAA20|VIIRS': '%s/archive/geoMetaVIIRS/5200/NOAA-20/%4.4d/VJ103MOD_%s.txt' % (server, date.year, date_s),
+        'SNPP|VIIRS'  : '%s/archive/geoMetaVIIRS/5110/NPP/%4.4d/VNP03MOD_%s.txt'   % (server, date.year, date_s),
+        }
+    fname_server = fnames_server[vname]
+    #\----------------------------------------------------------------------------/#
+
+
+    # convert longitude in [-180, 180] range
+    # since the longitude in GeoMeta dataset is in the range of [-180, 180]
+    #/----------------------------------------------------------------------------\#
+    lon[lon>180.0] -= 360.0
+    logic = (lon>=-180.0)&(lon<=180.0) & (lat>=-90.0)&(lat<=90.0)
+    lon   = lon[logic]
+    lat   = lat[logic]
+    #\----------------------------------------------------------------------------/#
+
+
+    # try to access the server
+    #/----------------------------------------------------------------------------\#
+
+    # try to get information from local
+    # check two locations:
+    #   1) <tmp-data/satfile> directory under er3t main directory
+    #   2) current directory;
+    #/--------------------------------------------------------------\#
+    fdir_satfile_tmp = '%s/satfile' % er3t.common.fdir_data_tmp
+    if not os.path.exists(fdir_satfile_tmp):
+        os.makedirs(fdir_satfile_tmp)
+
+    fname_local1 = os.path.abspath('%s/%s' % (fdir_satfile_tmp, os.path.basename(fname_server)))
+    fname_local2 = os.path.abspath('%s/%s' % (local           , os.path.basename(fname_server)))
+
+    if os.path.exists(fname_local1):
+        with open(fname_local1, 'r') as f_:
+            content = f_.read()
+
+    elif os.path.exists(fname_local2):
+        os.system('cp %s %s' % (fname_local2, fname_local1))
+        with open(fname_local2, 'r') as f_:
+            content = f_.read()
+    #\--------------------------------------------------------------/#
+
+    else:
+
+        # get information from server
+        #/--------------------------------------------------------------\#
+        try:
+            with requests.Session() as session:
+                session.auth = (username, password)
+                r1     = session.request('get', fname_server)
+                r      = session.get(r1.url, auth=(username, password))
+        except:
+            msg = '\nError [get_satfile_tag]: cannot access <%s>.' % fname_server
+            raise OSError(msg)
+
+        if r.ok:
+            content = r.content.decode('utf-8')
+        else:
+            msg = '\nError [get_satfile_tag]: failed to retrieve information from <%s>.' % fname_server
+            raise OSError(msg)
+        #\--------------------------------------------------------------/#
+    #\----------------------------------------------------------------------------/#
+
+    # extract granule information from <content>
+    # after the following session, granule information will be stored under <data>
+    # data['GranuleID'].decode('UTF-8') to get the file name of MODIS granule
+    # data['StartDateTime'].decode('UTF-8') to get the time stamp of MODIS granule
+    # variable names can be found through
+    # print(data.dtype.names)
+    #/----------------------------------------------------------------------------\#
+
+    if vname in ['Aqua|MODIS', 'Terra|MODIS']:
+        dtype = ['|S41', '|S1','<f8','<f8','<f8','<f8','<f8','<f8','<f8','<f8']
+    elif vname in ['NOAA20|VIIRS', 'SNPP|VIIRS']:
+        dtype = ['|S43', '|S1','<f8','<f8','<f8','<f8','<f8','<f8','<f8','<f8']
+    usecols = (0, 4, 9, 10, 11, 12, 13, 14, 15, 16)
+
+    #\----------------------------------------------------------------------------/#
+    # LAADS DAAC servers are known to cause some issues occasionally while
+    # accessing the metadata. We will attempt to read the txt file online directly
+    # on the server but as a backup, we will download the txt file locally and
+    # access the data there
+    #/----------------------------------------------------------------------------\#
+    try:
+        data  = np.genfromtxt(StringIO(content), delimiter=',', skip_header=2, names=True, dtype=dtype, invalid_raise=False, loose=True, usecols=usecols)
+    except ValueError:
+
+        msg = '\nError [get_satfile_tag]: failed to retrieve information from <%s>.\nAttempting to download the file to access the data...\n' % fname_server
+        print(msg)
+
+        try:
+            token = os.environ['EARTHDATA_TOKEN']
+        except KeyError:
+            token = 'aG9jaDQyNDA6YUc5dVp5NWphR1Z1TFRGQVkyOXNiM0poWkc4dVpXUjE6MTYzMzcyNTY5OTplNjJlODUyYzFiOGI3N2M0NzNhZDUxYjhiNzE1ZjUyNmI1ZDAyNTlk'
+
+        if verbose:
+            msg = '\nWarning [download_laads_https]: Please get a token by following the instructions at\nhttps://ladsweb.modaps.eosdis.nasa.gov/learn/download-files-using-laads-daac-tokens\nThen add the following to the source file of your shell, e.g. \'~/.bashrc\'(Unix) or \'~/.zshrc\'(Mac),\nexport EARTHDATA_TOKEN="XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"\n'
+            warnings.warn(msg)
+
+        try:
+            command = "wget -e robots=off -m -np -R .html,.tmp -nH --cut-dirs=3 {} --header \"Authorization: Bearer {}\" -O {}".format(fname_server, token, fname_local1)
+            os.system(command)
+            with open(fname_local1, 'r') as f_:
+                content = f_.read()
+            data = np.genfromtxt(StringIO(content), delimiter=',', skip_header=2, names=True, dtype=dtype, invalid_raise=False, loose=True, usecols=usecols)
+        except ValueError:
+            msg = '\nError [get_satfile_tag]: failed to retrieve information from <%s>.\nThis is likely an issue with LAADS DAAC servers, please try downloading the files manually or try again later.\n' % fname_server
+            raise OSError(msg)
+
+    #\----------------------------------------------------------------------------/#
+    # loop through all the "MODIS granules" constructed through four corner points
+    # and find which granules contain the input data
+    #/----------------------------------------------------------------------------\#
+    Ndata = data.size
+    filename_tags = []
+    proj_ori = ccrs.PlateCarree()
+    for i in range(Ndata):
+
+        line = data[i]
+        xx0  = np.array([line['GRingLongitude1'], line['GRingLongitude2'], line['GRingLongitude3'], line['GRingLongitude4'], line['GRingLongitude1']])
+        yy0  = np.array([line['GRingLatitude1'] , line['GRingLatitude2'] , line['GRingLatitude3'] , line['GRingLatitude4'] , line['GRingLatitude1']])
+
+        if (abs(xx0[0]-xx0[1])>180.0) | (abs(xx0[0]-xx0[2])>180.0) | \
+           (abs(xx0[0]-xx0[3])>180.0) | (abs(xx0[1]-xx0[2])>180.0) | \
+           (abs(xx0[1]-xx0[3])>180.0) | (abs(xx0[2]-xx0[3])>180.0):
+
+            xx0[xx0<0.0] += 360.0
+
+        # roughly determine the center of granule
+        #/----------------------------------------------------------------------------\#
+        xx = xx0[:-1]
+        yy = yy0[:-1]
+        center_lon = xx.mean()
+        center_lat = yy.mean()
+        #\----------------------------------------------------------------------------/#
+
+        # find the precise center point of MODIS granule
+        #/----------------------------------------------------------------------------\#
+        proj_tmp   = ccrs.Orthographic(central_longitude=center_lon, central_latitude=center_lat)
+        LonLat_tmp = proj_tmp.transform_points(proj_ori, xx, yy)[:, [0, 1]]
+        center_xx  = LonLat_tmp[:, 0].mean(); center_yy = LonLat_tmp[:, 1].mean()
+        center_lon, center_lat = proj_ori.transform_point(center_xx, center_yy, proj_tmp)
+        #\----------------------------------------------------------------------------/#
+
+        proj_new = ccrs.Orthographic(central_longitude=center_lon, central_latitude=center_lat)
+        LonLat_in = proj_new.transform_points(proj_ori, lon, lat)[:, [0, 1]]
+        LonLat_modis  = proj_new.transform_points(proj_ori, xx0, yy0)[:, [0, 1]]
+
+        modis_granule  = mpl_path.Path(LonLat_modis, closed=True)
+        pointsIn       = modis_granule.contains_points(LonLat_in)
+        percentIn      = float(pointsIn.sum()) * 100.0 / float(pointsIn.size)
+        if pointsIn.sum()>0 and percentIn>1 and data[i]['DayNightFlag'].decode('UTF-8')=='D':
+            filename = data[i]['GranuleID'].decode('UTF-8')
+            filename_tag = '.'.join(filename.split('.')[1:3])
+            filename_tags.append(filename_tag)
+
+    #\----------------------------------------------------------------------------/#
+    return filename_tags
+
+
+def get_nrt_satfile_tag(
+             date,
+             lon,
+             lat,
+             satellite='aqua',
+             instrument='modis',
+             server='https://nrt3.modaps.eosdis.nasa.gov/api/v2/content',
+             local='./',
+             verbose=False):
+
+    """
+    Input:
+        date: Python datetime.datetime object
+        lon : longitude of, e.g. flight track
+        lat : latitude of, e.g. flight track
+        satellite=: default "aqua", can also change to "terra", 'snpp', 'noaa20'
+        instrument=: default "modis", can also change to "viirs"
+        server=: string, data server
+        fdir_prefix=: string, data directory on NASA server
+        verbose=: Boolen type, verbose tag
+    output:
+        filename_tags: Python list of file name tags
+    """
+
+    # check cartopy and matplotlib
+    #/----------------------------------------------------------------------------\#
+    try:
+        import cartopy.crs as ccrs
+    except ImportError:
+        msg = '\nError [get_satfile_tag]: Please install <cartopy> to proceed.'
+        raise ImportError(msg)
+
+    try:
+        import matplotlib.path as mpl_path
+    except ImportError:
+        msg = '\nError [get_satfile_tag]: Please install <matplotlib> to proceed.'
+        raise ImportError(msg)
+    #\----------------------------------------------------------------------------/#
+
+
+    # check satellite and instrument
+    #/----------------------------------------------------------------------------\#
+    if instrument.lower() == 'modis' and (satellite.lower() in ['aqua', 'terra']):
+        instrument = instrument.upper()
+        satellite  = satellite.lower().title()
+    elif instrument.lower() == 'viirs' and (satellite.lower() in ['noaa20', 'snpp']):
+        instrument = instrument.upper()
+        satellite  = satellite.upper()
+    else:
+        msg = 'Error [get_satfile_tag]: Currently do not support <%s> onboard <%s>.' % (instrument, satellite)
+        raise NameError(msg)
+    #\----------------------------------------------------------------------------/#
+
+
+    # check login
+    #/----------------------------------------------------------------------------\#
+    try:
+        username = os.environ['EARTHDATA_USERNAME']
+        password = os.environ['EARTHDATA_PASSWORD']
+    except:
+        msg = '\nError [get_satfile_tag]: cannot find environment variables \'EARTHDATA_USERNAME\' and \'EARTHDATA_PASSWORD\'.'
+        raise OSError(msg)
+    #\----------------------------------------------------------------------------/#
+
+
+    # generate satellite filename on LAADS DAAC server
+    #/----------------------------------------------------------------------------\#
+    vname  = '%s|%s' % (satellite, instrument)
+    date_s = date.strftime('%Y-%m-%d')
+    fnames_server = {
+        'Aqua|MODIS'  : '%s/archives/geoMetaMODIS/61/AQUA/%4.4d/MYD03_%s.txt'           % (server, date.year, date_s),
+        'Terra|MODIS' : '%s/archives/geoMetaMODIS/61/TERRA/%4.4d/MOD03_%s.txt'          % (server, date.year, date_s),
         'NOAA20|VIIRS': '%s/archive/geoMetaJPSS/5200/JPSS1/%4.4d/VJ103MOD_%s.txt' % (server, date.year, date_s),
         'SNPP|VIIRS'  : '%s/archive/geoMetaJPSS/5110/NPP/%4.4d/VNP03MOD_%s.txt'   % (server, date.year, date_s),
         }
@@ -914,7 +1146,7 @@ def get_satfile_tag(
         modis_granule  = mpl_path.Path(LonLat_modis, closed=True)
         pointsIn       = modis_granule.contains_points(LonLat_in)
         percentIn      = float(pointsIn.sum()) / float(pointsIn.size) * 100.0
-        if pointsIn.sum()>0 and data[i]['DayNightFlag'].decode('UTF-8')=='D':
+        if pointsIn.sum()>0 and percentIn>0 and data[i]['DayNightFlag'].decode('UTF-8')=='D':
             filename = data[i]['GranuleID'].decode('UTF-8')
             filename_tag = '.'.join(filename.split('.')[1:3])
             filename_tags.append(filename_tag)

--- a/er3t/util/util.py
+++ b/er3t/util/util.py
@@ -7,8 +7,6 @@ import requests
 import urllib.request
 from io import StringIO
 import numpy as np
-from scipy import interpolate, stats
-from scipy.spatial import KDTree
 import warnings
 
 import er3t
@@ -272,6 +270,12 @@ def get_data_h4(hdf_dset):
 
 
 def move_correlate(data0, data, Ndx=5, Ndy=5):
+    
+    try:
+        from scipy import stats
+    except ImportError:
+        msg = '\nError [move_correlate]: `scipy` installation is required.'
+        raise ImportError(msg)
 
     Nx, Ny = data.shape
     x = np.arange(Nx, dtype=np.int32)
@@ -331,6 +335,12 @@ def find_nearest(x_raw, y_raw, data_raw, x_out, y_out, Ngrid_limit=1, fill_value
     Output:
         data_out: gridded data
     """
+    
+    try:
+        from scipy.spatial import KDTree
+    except ImportError:
+        msg = 'Error [find_nearest]: `scipy` installation is required.'
+        raise ImportError(msg)
 
     # only support output at maximum dimension of 2
     #/----------------------------------------------------------------------------\#
@@ -418,6 +428,12 @@ def grid_by_extent(lon, lat, data, extent=None, NxNy=None, method='nearest', fil
         After read in the longitude latitude and data into lon0, lat0, data0
         lon, lat, data = grid_by_extent(lon0, lat0, data0, extent=[10, 15, 10, 20])
     """
+    
+    try:
+        from scipy import interpolate
+    except ImportError:
+        msg = '\nError [grid_by_extent]: `scipy` installation is required.'
+        raise ImportError(msg)
 
     # flatten lon/lat/data
     #/----------------------------------------------------------------------------\#
@@ -483,6 +499,12 @@ def grid_by_lonlat(lon, lat, data, lon_1d=None, lat_1d=None, method='nearest', f
         After read in the longitude latitude and data into lon0, lat0, data0
         lon, lat, data = grid_by_lonlat(lon0, lat0, data0, lon_1d=np.linspace(10.0, 15.0, 100), lat_1d=np.linspace(10.0, 20.0, 100))
     """
+    
+    try:
+        from scipy import interpolate
+    except ImportError:
+        msg = '\nError [grid_by_lonlat]: `scipy` installation is required.'
+        raise ImportError(msg)
 
     # flatten lon/lat/data
     #/----------------------------------------------------------------------------\#
@@ -547,6 +569,12 @@ def grid_by_dxdy(lon, lat, data, extent=None, dx=None, dy=None, method='nearest'
         After read in the longitude latitude and data into lon0, lat0, data0
         lon, lat, data = grid_by_dxdy(lon0, lat0, data0, dx=250.0, dy=250.0)
     """
+    
+    try:
+        from scipy import interpolate
+    except ImportError:
+        msg = '\nError [grid_by_dxdy]: `scipy` installation is required.'
+        raise ImportError(msg)
 
     # flatten lon/lat/data
     #/----------------------------------------------------------------------------\#

--- a/er3t/util/util.py
+++ b/er3t/util/util.py
@@ -917,13 +917,14 @@ def get_satfile_tag(
         modis_granule  = mpl_path.Path(LonLat_modis, closed=True)
         pointsIn       = modis_granule.contains_points(LonLat_in)
         percentIn      = float(pointsIn.sum()) * 100.0 / float(pointsIn.size)
-        if pointsIn.sum()>0 and percentIn>1 and data[i]['DayNightFlag'].decode('UTF-8')=='D':
+        if pointsIn.sum()>0 and data[i]['DayNightFlag'].decode('UTF-8')=='D':
             filename = data[i]['GranuleID'].decode('UTF-8')
             filename_tag = '.'.join(filename.split('.')[1:3])
             filename_tags.append(filename_tag)
 
     #\----------------------------------------------------------------------------/#
     return filename_tags
+
 
 
 def get_nrt_satfile_tag(
@@ -1151,13 +1152,13 @@ def get_nrt_satfile_tag(
 
         modis_granule  = mpl_path.Path(LonLat_modis, closed=True)
         pointsIn       = modis_granule.contains_points(LonLat_in)
-        percentIn      = float(pointsIn.sum()) / float(pointsIn.size) * 100.0
-        if pointsIn.sum()>0 and percentIn>0 and data[i]['DayNightFlag'].decode('UTF-8')=='D':
+        percentIn      = float(pointsIn.sum()) * 100.0 / float(pointsIn.size)
+        if pointsIn.sum()>0 and data[i]['DayNightFlag'].decode('UTF-8')=='D':
             filename = data[i]['GranuleID'].decode('UTF-8')
             filename_tag = '.'.join(filename.split('.')[1:3])
             filename_tags.append(filename_tag)
-    #\----------------------------------------------------------------------------/#
 
+    #\----------------------------------------------------------------------------/#
     return filename_tags
 
 


### PR DESCRIPTION
This PR aims to:

1. Add easy download and access of/to VIIRS products from Suomi-NPP and NOAA-20 (JPSS1).
2. Add Near Real Time (NRT) products to the suite of downloads offered by `sdown`. This now includes both VIIRS and MODIS and can be tested using the `--nrt` command.

Big codebase changes include:
- addition of a new function `get_nrt_satfile_tag` to `er3t/util/util.py` for NRT support. This is mostly the same as `get_satfile_tag` developed by @hong-chen but the crucial change has to do with how links are managed by NRT LANCE DAAC.

Aims to directly resolve: https://github.com/hong-chen/er3t/issues/15