### PR TITLE
Improvements and Additions to MODIS and VIIRS suite of tools

### DIFF
--- a/bin/sdown
+++ b/bin/sdown
@@ -455,7 +455,7 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
 
         with open(os.path.join(fdir_out_dt, "metadata.txt"), "w") as f:
             f.write("Date: {}\n".format(single_dt))
-            f.write("Extent:{}\n".format(extent))
+            f.write("Extent: {}\n".format(extent))
 
         run(single_dt, extent, fdir_out_dt, nrt, products, verbose)
 

--- a/bin/sdown
+++ b/bin/sdown
@@ -233,7 +233,7 @@ _sat_tags_support_ = {
                 },
         
         'VJ102IMG': {
-                'dataset_tag': '5200/VJ102IMG',
+                'dataset_tag': '5201/VJ102IMG',
                    'dict_key': 'vj1_02',
                 'description': 'JPSS1 (NOAA-20) VIIRS Level 1b (375m) Calibrated Radiances Product',
                     'website': 'https://doi.org/10.5067/VIIRS/VJ102IMG.021',
@@ -254,7 +254,7 @@ _sat_tags_support_ = {
                 },
         
         'VJ102MOD': {
-                'dataset_tag': '5200/VJ102MOD',
+                'dataset_tag': '5201/VJ102MOD',
                    'dict_key': 'vj1_02',
                 'description': 'JPSS1 (NOAA-20) VIIRS Level 1b (750m) Calibrated Radiances Product',
                     'website': 'https://doi.org/10.5067/VIIRS/VJ102MOD.021',
@@ -274,7 +274,7 @@ _sat_tags_support_ = {
                 },
         
         'VJ103IMG': {
-                'dataset_tag': '5200/VJ103IMG',
+                'dataset_tag': '5201/VJ103IMG',
                    'dict_key': 'vj1_03',
                 'description': 'JPSS1 (NOAA-20) VIIRS (375m) Geolocation Fields Product',
                     'website': 'https://doi.org/10.5067/VIIRS/VJ103IMG.021',
@@ -294,7 +294,7 @@ _sat_tags_support_ = {
                 },
         
         'VJ103MOD': {
-                'dataset_tag': '5200/VJ103MOD',
+                'dataset_tag': '5201/VJ103MOD',
                    'dict_key': 'vj1_03',
                 'description': 'JPSS1 (NOAA-20) VIIRS (750m) Geolocation Fields Product',
                     'website': 'https://doi.org/10.5067/VIIRS/VJ103MOD.021',
@@ -314,7 +314,7 @@ _sat_tags_support_ = {
                 },
         
         'VJ1RGB': {
-                'dataset_tag': '5200/VJ1RGB',
+                'dataset_tag': '5201/VJ1RGB',
                    'dict_key': 'vj1_rgb',
                 'description': 'JPSS1 (NOAA-20) VIIRS True Color (RGB) Imagery',
                     'website': 'https://worldview.earthdata.nasa.gov',

--- a/bin/sdown
+++ b/bin/sdown
@@ -18,7 +18,7 @@ Now supports:
                 VNP02IMG,       VJ102IMG
                 VNP03MOD,       VJ103MOD
                 VNP02MOD,       VJ102MOD
-                VNP_CLDPROP_L2, VNP_CLDPROP_L2
+                CLDPROP_L2_VIIRS_SNPP, CLDPROP_L2_VIIRS_NOAA20
     
     OCO-2 data: coming soon...
 
@@ -330,7 +330,7 @@ _sat_tags_support_ = {
                     'website': 'https://doi.org/10.5067/VIIRS/CLDPROP_L2_VIIRS_SNPP.011',
                   'satellite': 'SNPP',
                  'instrument': 'VIIRS',
-                  'reference': 'placeholder',
+                  'reference': 'NASA VIIRS Atmosphere SIPS. 2019-11-15. VIIRS/SNPP Cloud Properties 6-min L2 Swath 750m. Version 1.1. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS).',
                 },
 
         'VJ1_CLDPROP_L2': {
@@ -340,7 +340,7 @@ _sat_tags_support_ = {
                     'website': 'https://ladsweb.modaps.eosdis.nasa.gov/missions-and-measurements/products/CLDPROP_L2_VIIRS_NOAA20',
                   'satellite': 'NOAA20',
                  'instrument': 'VIIRS',
-                  'reference': 'placeholder',
+                  'reference': 'NASA VIIRS Atmosphere SIPS. 2019-11-15. VIIRS/JPSS1 Cloud Properties 6-min L2 Swath 750m. Version 1.1. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS).',
                 },
 
         'oco2_L1bScND': {
@@ -454,8 +454,8 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
             os.makedirs(fdir_out_dt)
 
         with open(os.path.join(fdir_out_dt, "metadata.txt"), "w") as f:
-            f.write("Date: {}\n".format(single_dt))
-            f.write("Extent: {}\n".format(extent))
+            f.write("DATE:{}\n".format(single_dt))
+            f.write("EXTENT:{}\n".format(extent))
 
         run(single_dt, extent, fdir_out_dt, nrt, products, verbose)
 
@@ -513,8 +513,8 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
 
             # Save metadata
             with open(os.path.join(fdir_out_dt, "metadata.txt"), "w") as f:
-                f.write('Date: {}\n'.format(date_x))
-                f.write('Extent: {}\n'.format(extent))
+                f.write('DATE:{}\n'.format(date_x))
+                f.write('EXTENT:{}\n'.format(extent))
 
             print("Obtaining data for: ", date_x, extent)
             run(date_x, extent, fdir_out_dt, nrt, products, verbose)
@@ -696,6 +696,18 @@ if __name__ == '__main__':
                         'MODRGB  :  True-Color RGB (Terra) imagery, useful for visuzliation\n'\
                         'MYDRGB  :  True-Color RGB (Aqua)  imagery, useful for visuzliation\n'\
                         'MCD43   :  Level 3 surface product MCD43A3\n'\
+                        'VNPRGB  :  True-Color RGB (S-NPP) imagery, useful for visuzliation\n'\
+                        'VJ1RGB  :  True-Color RGB (NOAA-20) imagery, useful for visuzliation\n'\
+                        'VNP02IMG:  Level 1b 375m (S-NPP) radiance product\n'\
+                        'VJ102IMG:  Level 1b 375m (NOAA-20) radiance product\n'\
+                        'VNP03IMG:  Solar/viewing geometry 375m (S-NPP) product\n'\
+                        'VJ103IMG:  Solar/viewing geometry 375m (NOAA-20) product\n'
+                        'VNP02MOD:  Level 1b 750m (S-NPP) radiance product\n'\
+                        'VJ102MOD:  Level 1b 750m (NOAA-20) radiance product\n'\
+                        'VNP03MOD:  Solar/viewing geometry 750m (S-NPP) product\n'\
+                        'VJ103MOD:  Solar/viewing geometry 750m (NOAA-20) product\n'\
+                        'CLDPROP_L2_VIIRS_SNPP: Level 2 (S-NPP) cloud properties product\n'\
+                        'CLDPROP_L2_VIIRS_NOAA20: Level 2(NOAA-20) cloud properties product\n'\
                         '\nTo download multiple products at a time:\n'\
                         '--products MOD021KM VJ102MOD MYD06_l2\n \n')
 

--- a/bin/sdown
+++ b/bin/sdown
@@ -433,7 +433,7 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
             msg = '\nError [sdown]: Received %s as date of interest but data for MODIS onboard Aqua only exists from %s. Retry with more recent dates.\n' % (single_dt.strftime("%d %B, %Y"), _aqua_modis_start_date.strftime("%d %B, %Y"))
             sys.exit(msg)
 
-        if len(modis_terra) > 0 and single_dt < _aqua_terra_start_date:
+        if len(modis_terra) > 0 and single_dt < _terra_modis_start_date:
             msg = '\nError [sdown]: Received %s as date of interest but data for MODIS onboard Terra only exists from %s. Retry with more recent dates.\n' % (single_dt.strftime("%d %B, %Y"), _terra_modis_start_date.strftime("%d %B, %Y"))
             sys.exit(msg)
         
@@ -455,7 +455,7 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
 
         with open(os.path.join(fdir_out_dt, "metadata.txt"), "w") as f:
             f.write("Date: {}\n".format(single_dt))
-            f.write("Extent: {}\n".format(extent))
+            f.write("Extent:{}\n".format(extent))
 
         run(single_dt, extent, fdir_out_dt, nrt, products, verbose)
 
@@ -485,7 +485,7 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
             msg = '\nError [sdown]: Received %s as starting date of interest but data for MODIS onboard Aqua only exists from %s. Retry with more recent dates.\n' % (start_dt.strftime("%d %B, %Y"), _aqua_modis_start_date.strftime("%d %B, %Y"))
             sys.exit(msg)
 
-        if len(modis_terra) > 0 and start_dt < _aqua_terra_start_date:
+        if len(modis_terra) > 0 and start_dt < _terra_modis_start_date:
             msg = '\nError [sdown]: Received %s as starting date of interest but data for MODIS onboard Terra only exists from %s. Retry with more recent dates.\n' % (start_dt.strftime("%d %B, %Y"), _terra_modis_start_date.strftime("%d %B, %Y"))
             sys.exit(msg)
 
@@ -562,7 +562,7 @@ def run(date, extent, fdir_out, nrt, products, verbose):
                 fnames[product_info['dict_key']] += p_fnames
 
         # MODIS Level-1b radiances, Level-2 cloud products, and solar/viewing geoemetries
-        elif product.upper().endswith(('QKM', 'HKM', '1KM', 'L2', '03', '02IMG', '02MOD', '03IMG', '03MOD')):
+        elif product.upper().endswith(('QKM', 'HKM', '1KM', 'L2', '03', '02IMG', '02MOD', '03IMG', '03MOD', 'L2_VIIRS_NOAA20', 'L2_VIIRS_SNPP')):
             if nrt:
                 link_to_nrt = 'https://www.earthdata.nasa.gov/learn/find-data/near-real-time/near-real-time-versus-standard-products'
                 msg = 'Warning [sdown]: Downloading Near Real Time (NRT) products. \n'\

--- a/bin/sdown
+++ b/bin/sdown
@@ -454,8 +454,8 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
             os.makedirs(fdir_out_dt)
 
         with open(os.path.join(fdir_out_dt, "metadata.txt"), "w") as f:
-            f.write("DATE:{}\n".format(single_dt))
-            f.write("EXTENT:{}\n".format(extent))
+            f.write("Date: {}\n".format(single_dt))
+            f.write("Extent: {}\n".format(extent))
 
         run(single_dt, extent, fdir_out_dt, nrt, products, verbose)
 
@@ -513,8 +513,8 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
 
             # Save metadata
             with open(os.path.join(fdir_out_dt, "metadata.txt"), "w") as f:
-                f.write('DATE:{}\n'.format(date_x))
-                f.write('EXTENT:{}\n'.format(extent))
+                f.write('Date: {}\n'.format(date_x))
+                f.write('Extent: {}\n'.format(extent))
 
             print("Obtaining data for: ", date_x, extent)
             run(date_x, extent, fdir_out_dt, nrt, products, verbose)

--- a/er3t/util/modis.py
+++ b/er3t/util/modis.py
@@ -94,12 +94,10 @@ class modis_l1b:
 
         f     = SD(fname, SDC.READ)
 
-        # lon lat
-        lat0       = f.select('Latitude')
-        lon0       = f.select('Longitude')
-
         # when resolution equals to 250 m
         if check_equal(self.resolution, 0.25):
+            lat0      = f.select('Latitude')
+            lon0      = f.select('Longitude')
             lon, lat  = upscale_modis_lonlat(lon0[:], lat0[:], scale=4, extra_grid=False)
             raw0      = f.select('EV_250_RefSB')
             uct0      = f.select('EV_250_RefSB_Uncert_Indexes')
@@ -108,6 +106,8 @@ class modis_l1b:
 
         # when resolution equals to 500 m
         elif check_equal(self.resolution, 0.5):
+            lat0      = f.select('Latitude')
+            lon0      = f.select('Longitude')
             lon, lat  = upscale_modis_lonlat(lon0[:], lat0[:], scale=2, extra_grid=False)
             raw0      = f.select('EV_500_RefSB')
             uct0      = f.select('EV_500_RefSB_Uncert_Indexes')
@@ -117,9 +117,25 @@ class modis_l1b:
         # when resolution equals to 1000 m
         elif check_equal(self.resolution, 1.0):
             if self.f03 is not None:
-                raw0      = f.select('EV_250_Aggr1km_RefSB')
-                uct0      = f.select('EV_250_Aggr1km_RefSB_Uncert_Indexes')
-                wvl       = np.array([650.0, 860.0])
+                raw0_250  = f.select('EV_250_Aggr1km_RefSB')
+                uct0_250  = f.select('EV_250_Aggr1km_RefSB_Uncert_Indexes')
+                raw0_500  = f.select('EV_500_Aggr1km_RefSB')
+                uct0_500  = f.select('EV_500_Aggr1km_RefSB_Uncert_Indexes')
+                
+                # save offsets and scaling factors (from both visible and near infrared bands)
+                rad_off = raw0_250.attributes()['radiance_offsets'] + raw0_500.attributes()['radiance_offsets']
+                rad_sca = raw0_250.attributes()['radiance_scales'] + raw0_500.attributes()['radiance_offsets']
+                ref_off = raw0_250.attributes()['reflectance_offsets'] + raw0_500.attributes()['reflectance_offsets']
+                ref_sca = raw0_250.attributes()['reflectance_scales'] + raw0_500.attributes()['reflectance_offsets']
+                cnt_off = raw0_250.attributes()['corrected_counts_offsets'] + raw0_500.attributes()['corrected_counts_offsets']
+                cnt_sca = raw0_250.attributes()['corrected_counts_scales'] + raw0_500.attributes()['corrected_counts_offsets']
+                uct_spc = uct0_250.attributes()['specified_uncertainty'] + uct0_500.attributes()['specified_uncertainty']
+                uct_sca = uct0_250.attributes()['scaling_factor'] + uct0_500.attributes()['scaling_factor']
+                
+                # combine visible and near infrared bands
+                raw0      = np.vstack([raw0_250, raw0_500])
+                uct0      = np.vstack([uct0_250, uct0_500])
+                wvl       = np.array([650.0, 860.0, 470.0, 555.0, 1240.0, 1640.0, 2130.0])
                 do_region = False
                 lon       = self.f03.data['lon']['data']
                 lat       = self.f03.data['lat']['data']
@@ -156,6 +172,19 @@ class modis_l1b:
             logic     = (lon>=lon_range[0]) & (lon<=lon_range[1]) & (lat>=lat_range[0]) & (lat<=lat_range[1])
             lon       = lon[logic]
             lat       = lat[logic]
+            
+            # save offsets and scaling factors
+            rad_off = raw0.attributes()['radiance_offsets']
+            rad_sca = raw0.attributes()['radiance_scales']
+
+            ref_off = raw0.attributes()['reflectance_offsets']
+            ref_sca = raw0.attributes()['reflectance_scales']
+
+            cnt_off = raw0.attributes()['corrected_counts_offsets']
+            cnt_sca = raw0.attributes()['corrected_counts_scales']
+
+            uct_spc = uct0.attributes()['specified_uncertainty']
+            uct_sca = uct0.attributes()['scaling_factor']
         # -------------------------------------------------------------------------------------------------
 
 
@@ -165,20 +194,6 @@ class modis_l1b:
         rad = np.zeros(raw.shape, dtype=np.float64)
         ref = np.zeros(raw.shape, dtype=np.float64)
         cnt = np.zeros(raw.shape, dtype=np.float64)
-
-        # save offsets and scaling factors
-        rad_off = raw0.attributes()['radiance_offsets']
-        rad_sca = raw0.attributes()['radiance_scales']
-
-        ref_off = raw0.attributes()['reflectance_offsets']
-        ref_sca = raw0.attributes()['reflectance_scales']
-
-        cnt_off = raw0.attributes()['corrected_counts_offsets']
-        cnt_sca = raw0.attributes()['corrected_counts_scales']
-
-        uct_spc = uct0.attributes()['specified_uncertainty']
-        uct_sca = uct0.attributes()['scaling_factor']
-
 
         # Calculate uncertainty
         uct     = uct0[:][:, logic]
@@ -199,8 +214,8 @@ class modis_l1b:
 
         if hasattr(self, 'data'):
             if do_region:
-                self.data['lon'] = dict(name='Longitude'               , data=np.hstack((self.data['lon']['data'], lon)), units='degrees')
-                self.data['lat'] = dict(name='Latitude'                , data=np.hstack((self.data['lat']['data'], lat)), units='degrees')
+                self.data['lon'] = dict(name='Longitude'           , data=np.hstack((self.data['lon']['data'], lon)), units='degrees')
+                self.data['lat'] = dict(name='Latitude'            , data=np.hstack((self.data['lat']['data'], lat)), units='degrees')
 
             self.data['rad'] = dict(name='Radiance'                , data=np.hstack((self.data['rad']['data'], rad)), units='W/m^2/nm/sr')
             self.data['ref'] = dict(name='Reflectance (x cos(SZA))', data=np.hstack((self.data['ref']['data'], ref)), units='N/A')

--- a/er3t/util/modis.py
+++ b/er3t/util/modis.py
@@ -118,6 +118,7 @@ class modis_l1b:
         elif check_equal(self.resolution, 1.0):
             if self.f03 is not None:
                 raw0      = f.select('EV_250_Aggr1km_RefSB')
+                uct0      = f.select('EV_250_Aggr1km_RefSB_Uncert_Indexes')
                 wvl       = np.array([650.0, 860.0])
                 do_region = False
                 lon       = self.f03.data['lon']['data']
@@ -129,30 +130,32 @@ class modis_l1b:
         else:
             sys.exit('Error   [modis_l1b]: \'resolution=%f\' has not been implemented.' % self.resolution)
 
-
+        
         # 1. If region (extent=) is specified, filter data within the specified region
         # 2. If region (extent=) is not specified, filter invalid data
         #/----------------------------------------------------------------------------\#
-        if self.extent is None:
+        
+        if do_region: # applied only for QKM (250m) or HKM (500m) products
+            if self.extent is None:
 
-            if 'actual_range' in lon0.attributes().keys():
-                lon_range = lon0.attributes()['actual_range']
-                lat_range = lat0.attributes()['actual_range']
-            elif 'valid_range' in lon0.attributes().keys():
-                lon_range = lon0.attributes()['valid_range']
-                lat_range = lat0.attributes()['valid_range']
+                if 'actual_range' in lon0.attributes().keys():
+                    lon_range = lon0.attributes()['actual_range']
+                    lat_range = lat0.attributes()['actual_range']
+                elif 'valid_range' in lon0.attributes().keys():
+                    lon_range = lon0.attributes()['valid_range']
+                    lat_range = lat0.attributes()['valid_range']
+                else:
+                    lon_range = [-180.0, 180.0]
+                    lat_range = [-90.0 , 90.0]
+
             else:
-                lon_range = [-180.0, 180.0]
-                lat_range = [-90.0 , 90.0]
 
-        else:
+                lon_range = [self.extent[0] - 0.01, self.extent[1] + 0.01]
+                lat_range = [self.extent[2] - 0.01, self.extent[3] + 0.01]
 
-            lon_range = [self.extent[0] - 0.01, self.extent[1] + 0.01]
-            lat_range = [self.extent[2] - 0.01, self.extent[3] + 0.01]
-
-        logic     = (lon>=lon_range[0]) & (lon<=lon_range[1]) & (lat>=lat_range[0]) & (lat<=lat_range[1])
-        lon       = lon[logic]
-        lat       = lat[logic]
+            logic     = (lon>=lon_range[0]) & (lon<=lon_range[1]) & (lat>=lat_range[0]) & (lat<=lat_range[1])
+            lon       = lon[logic]
+            lat       = lat[logic]
         # -------------------------------------------------------------------------------------------------
 
 

--- a/er3t/util/modis.py
+++ b/er3t/util/modis.py
@@ -51,7 +51,7 @@ class modis_l1b:
                  verbose   = False):
 
         self.fnames     = fnames      # file name of the hdf files
-        self.f03        = f03         # geolocation file
+        self.f03        = f03         # geolocation class object created using the `modis_03` reader
         self.extent     = extent      # specified region [westmost, eastmost, southmost, northmost]
         self.verbose    = verbose     # verbose tag
 


### PR DESCRIPTION
This PR does a lot of things

### Major changes:

1. VIIRS L1b and L2 cloud products can now be downloaded via `sdown`. See changes in `bin/sdown`
    - Extensive error handling has been included since this tool is oriented towards the larger community
2. VIIRS Near Real Time Products (NRT) are also now supported alongside MODIS NRT products. They can be downloaded by simply passing `--nrt` when calling `sdown`.
3. Adds a reader for VIIRS Level 2 Cloud products (CLDPROP_L2_VIIRS_****). Changes in `er3t/util/viirs.py`
4. Fixes a bug in MODIS L1b reader when handling 1km products. Changes in `er3t/util/modis.py`
5. Adds functionality to extract both visible and near-infrared bands from the 1km product as part of the L1b reader. Changes again in `er3t/util/modis.py`

Minor changes:
- Mostly simple bug fixes and spacing/aesthetic things