### PR TITLE
Bug fixes for `sdown` and MODIS/VIIRS readers

### DIFF
--- a/bin/sdown
+++ b/bin/sdown
@@ -18,7 +18,7 @@ Now supports:
                 VNP02IMG,       VJ102IMG
                 VNP03MOD,       VJ103MOD
                 VNP02MOD,       VJ102MOD
-                CLDPROP_L2_VIIRS_SNPP, CLDPROP_L2_VIIRS_NOAA20
+                VNP_CLDPROP_L2, VJ1_CLDPROP_L2
     
     OCO-2 data: coming soon...
 
@@ -54,8 +54,8 @@ _description_ = '=' * _width_ + '\n\n' + \
                 '=' * _width_ + '\n' + \
                 ' Satellite Data Product Download Tool '.center(_width_, '=') + '\n\n' + \
                 'Example Usage:\n'\
-                'sdown --date 20210523 --lons 30 35 --lats 0 10 --products MOD06_L2 --fdir_out sat-data/ --verbose\n'\
-                'sdown --date 20130714 --extent 30 35 0 10 --products MODRGB MYD02QKM --fdir_out sat-data/\n'
+                'sdown --date 20210523 --lons 30 35 --lats 0 10 --products MOD06_L2 --fdir sat-data/ --verbose\n'\
+                'sdown --date 20130714 --extent 30 35 0 10 --products MODRGB MYD02QKM --fdir sat-data/\n'
 
 
 # product tags
@@ -706,8 +706,8 @@ if __name__ == '__main__':
                         'VJ102MOD:  Level 1b 750m (NOAA-20) radiance product\n'\
                         'VNP03MOD:  Solar/viewing geometry 750m (S-NPP) product\n'\
                         'VJ103MOD:  Solar/viewing geometry 750m (NOAA-20) product\n'\
-                        'CLDPROP_L2_VIIRS_SNPP: Level 2 (S-NPP) cloud properties product\n'\
-                        'CLDPROP_L2_VIIRS_NOAA20: Level 2(NOAA-20) cloud properties product\n'\
+                        'VNP_CLDPROP_L2: Level 2 (S-NPP) cloud properties product\n'\
+                        'VJ1_CLDPROP_L2: Level 2 (NOAA-20) cloud properties product\n'\
                         '\nTo download multiple products at a time:\n'\
                         '--products MOD021KM VJ102MOD MYD06_l2\n \n')
 

--- a/bin/sdown
+++ b/bin/sdown
@@ -562,7 +562,7 @@ def run(date, extent, fdir_out, nrt, products, verbose):
                 fnames[product_info['dict_key']] += p_fnames
 
         # MODIS Level-1b radiances, Level-2 cloud products, and solar/viewing geoemetries
-        elif product.upper().endswith(('QKM', 'HKM', '1KM', 'L2', '03', '02IMG', '02MOD', '03IMG', '03MOD', 'L2_VIIRS_NOAA20', 'L2_VIIRS_SNPP')):
+        elif product.upper().endswith(('QKM', 'HKM', '1KM', 'L2', '03', '02IMG', '02MOD', '03IMG', '03MOD', 'VNP_CLDPROP_L2', 'VJ1_CLDPROP_L2')):
             if nrt:
                 link_to_nrt = 'https://www.earthdata.nasa.gov/learn/find-data/near-real-time/near-real-time-versus-standard-products'
                 msg = 'Warning [sdown]: Downloading Near Real Time (NRT) products. \n'\

--- a/er3t/util/modis.py
+++ b/er3t/util/modis.py
@@ -124,11 +124,11 @@ class modis_l1b:
                 
                 # save offsets and scaling factors (from both visible and near infrared bands)
                 rad_off = raw0_250.attributes()['radiance_offsets'] + raw0_500.attributes()['radiance_offsets']
-                rad_sca = raw0_250.attributes()['radiance_scales'] + raw0_500.attributes()['radiance_offsets']
+                rad_sca = raw0_250.attributes()['radiance_scales'] + raw0_500.attributes()['radiance_scales']
                 ref_off = raw0_250.attributes()['reflectance_offsets'] + raw0_500.attributes()['reflectance_offsets']
-                ref_sca = raw0_250.attributes()['reflectance_scales'] + raw0_500.attributes()['reflectance_offsets']
+                ref_sca = raw0_250.attributes()['reflectance_scales'] + raw0_500.attributes()['reflectance_scales']
                 cnt_off = raw0_250.attributes()['corrected_counts_offsets'] + raw0_500.attributes()['corrected_counts_offsets']
-                cnt_sca = raw0_250.attributes()['corrected_counts_scales'] + raw0_500.attributes()['corrected_counts_offsets']
+                cnt_sca = raw0_250.attributes()['corrected_counts_scales'] + raw0_500.attributes()['corrected_counts_scales']
                 uct_spc = uct0_250.attributes()['specified_uncertainty'] + uct0_500.attributes()['specified_uncertainty']
                 uct_sca = uct0_250.attributes()['scaling_factor'] + uct0_500.attributes()['scaling_factor']
                 

--- a/er3t/util/viirs.py
+++ b/er3t/util/viirs.py
@@ -416,7 +416,7 @@ class viirs_cldprop_l2:
         
         
         #------------------------------------Cloud variables------------------------------------#
-        ctp0 = f.groups['geophysical_data'].variables['Cloud_Top_Pressure']
+        ctp0 = f.groups['geophysical_data'].variables['Cloud_Phase_Optical_Properties']
         cth0 = f.groups['geophysical_data'].variables['Cloud_Top_Height']
         
         
@@ -454,7 +454,7 @@ class viirs_cldprop_l2:
         lat           = lat[logic_extent]
         
         # Retrieve 1. ctp, 2. cth, 3. cot, 4. cer, 5. cwp, and select regional extent
-        ctp           = get_data_nc(ctp0)[logic_extent]
+        ctp           = get_data_nc(ctp0, nan=False)[logic_extent]
         cth           = get_data_nc(cth0, nan=False)[logic_extent]
         ctp_uct       = get_data_nc(ctp_uct0)[logic_extent]
         cth_uct       = get_data_nc(cth_uct0)[logic_extent]
@@ -506,7 +506,7 @@ class viirs_cldprop_l2:
 
             self.data['lon']      = dict(name='Longitude',                           data=np.hstack((self.data['lon']['data'], lon)),                   units='degrees')
             self.data['lat']      = dict(name='Latitude',                            data=np.hstack((self.data['lat']['data'], lat)),                   units='degrees')
-            self.data['ctp']      = dict(name='Cloud top pressure',                  data=np.hstack((self.data['ctp']['data'], ctp)),                   units='mb')
+            self.data['ctp']      = dict(name='Cloud phase optical proprties',                  data=np.hstack((self.data['ctp']['data'], ctp)),                   units='N/A')
             self.data['cth']      = dict(name='Cloud top height',                    data=np.hstack((self.data['cth']['data'], cth)),                   units='m')
             self.data['cot']      = dict(name='Cloud optical thickness',             data=np.hstack((self.data['cot']['data'], cot)),                   units='N/A')
             self.data['cer']      = dict(name='Cloud effective radius',              data=np.hstack((self.data['cer']['data'], cer)),                   units='micron')
@@ -525,7 +525,7 @@ class viirs_cldprop_l2:
             
             self.data['lon']      = dict(name='Longitude',                           data=lon,               units='degrees')
             self.data['lat']      = dict(name='Latitude',                            data=lat,               units='degrees')
-            self.data['ctp']      = dict(name='Cloud top pressure',                  data=ctp,               units='mb')
+            self.data['ctp']      = dict(name='Cloud phase optical properties',      data=ctp,               units='N/A')
             self.data['cth']      = dict(name='Cloud top height',                    data=cth,               units='m')
             self.data['cot']      = dict(name='Cloud optical thickness',             data=cot,               units='N/A')
             self.data['cer']      = dict(name='Cloud effective radius',              data=cer,               units='micron')

--- a/er3t/util/viirs.py
+++ b/er3t/util/viirs.py
@@ -479,8 +479,8 @@ class viirs_cldprop_l2:
         
         # use the partially cloudy data to fill in potential missed clouds
         pcl     = np.zeros_like(cot, dtype=np.uint8)
-        logic_pcl = ((cot0_data < 0.0) | (cer0_data <= 0.0) | (cwp0_data <= 0.0)) &\
-                    ((cot1_data >= 0.0) & (cer1_data > 0.0) & (cwp1_data > 0.0))
+        logic_pcl = ((cot0_data < 0.0) | (cer0_data <= 0.0) | (cwp0_data < 0.0)) &\
+                    ((cot1_data >= 0.0) & (cer1_data > 0.0) & (cwp1_data >= 0.0))
         
         pcl[logic_pcl] = 1
         cot[logic_pcl] = cot1_data[logic_pcl]
@@ -488,7 +488,7 @@ class viirs_cldprop_l2:
         cwp[logic_pcl] = cwp1_data[logic_pcl]
         
         # make invalid pixels clear-sky
-        logic_invalid = (cot < 0.0) | (cer <= 0.0) | (cwp <= 0.0)
+        logic_invalid = (cot < 0.0) | (cer <= 0.0) | (cwp < 0.0)
         cot[logic_invalid]     = 0.0
         cer[logic_invalid]     = 1.0
         cwp[logic_invalid]     = 1.0

--- a/er3t/util/viirs.py
+++ b/er3t/util/viirs.py
@@ -453,8 +453,6 @@ class viirs_cldprop_l2:
         # Retrieve 1. ctp, 2. cth, 3. cot, 4. cer, 5. cwp, and select regional extent
         ctp           = get_data_nc(ctp0, nan=False)[logic_extent]
         cth           = get_data_nc(cth0, nan=False)[logic_extent]
-        ctp_uct       = get_data_nc(ctp_uct0)[logic_extent]
-        cth_uct       = get_data_nc(cth_uct0)[logic_extent]
         
         cot0_data     = get_data_nc(cot0)[logic_extent]
         cer0_data     = get_data_nc(cer0)[logic_extent]
@@ -488,7 +486,7 @@ class viirs_cldprop_l2:
         logic_invalid = (cot < 0.0) | (cer <= 0.0) | (cwp < 0.0)
         cot[logic_invalid]     = 0.0
         cer[logic_invalid]     = 1.0
-        cwp[logic_invalid]     = 1.0
+        cwp[logic_invalid]     = 0.0
         cot_uct[logic_invalid] = 0.0
         cer_uct[logic_invalid] = 0.0
         cwp_uct[logic_invalid] = 0.0
@@ -503,7 +501,7 @@ class viirs_cldprop_l2:
 
             self.data['lon']      = dict(name='Longitude',                           data=np.hstack((self.data['lon']['data'], lon)),                   units='degrees')
             self.data['lat']      = dict(name='Latitude',                            data=np.hstack((self.data['lat']['data'], lat)),                   units='degrees')
-            self.data['ctp']      = dict(name='Cloud phase optical proprties',                  data=np.hstack((self.data['ctp']['data'], ctp)),                   units='N/A')
+            self.data['ctp']      = dict(name='Cloud phase optical proprties',       data=np.hstack((self.data['ctp']['data'], ctp)),                   units='N/A')
             self.data['cth']      = dict(name='Cloud top height',                    data=np.hstack((self.data['cth']['data'], cth)),                   units='m')
             self.data['cot']      = dict(name='Cloud optical thickness',             data=np.hstack((self.data['cot']['data'], cot)),                   units='N/A')
             self.data['cer']      = dict(name='Cloud effective radius',              data=np.hstack((self.data['cer']['data'], cer)),                   units='micron')

--- a/er3t/util/viirs.py
+++ b/er3t/util/viirs.py
@@ -421,7 +421,6 @@ class viirs_cldprop_l2:
         
         
         # TODO
-        # Support for cloud phase properties (byte format)
         # Support for cloud mask             (byte format)
         cot0 = f.groups['geophysical_data'].variables['Cloud_Optical_Thickness']
         cer0 = f.groups['geophysical_data'].variables['Cloud_Effective_Radius']
@@ -433,8 +432,6 @@ class viirs_cldprop_l2:
         cwp1 = f.groups['geophysical_data'].variables['Cloud_Water_Path_PCL']
         
         #-------------------------------------Uncertainties-------------------------------------#
-        ctp_uct0 = f.groups['geophysical_data'].variables['Cloud_Top_Pressure_Uncertainty']
-        cth_uct0 = f.groups['geophysical_data'].variables['Cloud_Top_Height_Uncertainty']
         cot_uct0 = f.groups['geophysical_data'].variables['Cloud_Optical_Thickness_Uncertainty']
         cer_uct0 = f.groups['geophysical_data'].variables['Cloud_Effective_Radius_Uncertainty']
         cwp_uct0 = f.groups['geophysical_data'].variables['Cloud_Water_Path_Uncertainty']
@@ -511,11 +508,9 @@ class viirs_cldprop_l2:
             self.data['cot']      = dict(name='Cloud optical thickness',             data=np.hstack((self.data['cot']['data'], cot)),                   units='N/A')
             self.data['cer']      = dict(name='Cloud effective radius',              data=np.hstack((self.data['cer']['data'], cer)),                   units='micron')
             self.data['cwp']      = dict(name='Cloud water path',                    data=np.hstack((self.data['cwp']['data'], cwp)),                   units='g/m^2')
-            self.data['ctp_uct']  = dict(name='Cloud top pressure uncertainty',      data=np.hstack((self.data['ctp_uct']['data'], ctp*ctp_uct/100.0)), units='mb')
-            self.data['cth_uct']  = dict(name='Cloud top height uncertainty',        data=np.hstack((self.data['cth_uct']['data'], cth*cth_uct/100.0)), units='m')
             self.data['cot_uct']  = dict(name='Cloud optical thickness uncertainty', data=np.hstack((self.data['cot_uct']['data'], cot*cot_uct/100.0)), units='N/A')
             self.data['cer_uct']  = dict(name='Cloud effective radius uncertainty',  data=np.hstack((self.data['cer_uct']['data'], cer*cer_uct/100.0)), units='micron')
-            self.data['cer_uct']  = dict(name='Cloud water path uncertainty',        data=np.hstack((self.data['cwp_uct']['data'], cwp*cwp_uct/100.0)), units='g/m^2')
+            self.data['cwp_uct']  = dict(name='Cloud water path uncertainty',        data=np.hstack((self.data['cwp_uct']['data'], cwp*cwp_uct/100.0)), units='g/m^2')
             self.data['pcl']      = dict(name='PCL tag (1:PCL, 0:Cloudy)',           data=np.hstack((self.data['pcl']['data'], pcl)),                   units='N/A')
 
         else:
@@ -530,11 +525,9 @@ class viirs_cldprop_l2:
             self.data['cot']      = dict(name='Cloud optical thickness',             data=cot,               units='N/A')
             self.data['cer']      = dict(name='Cloud effective radius',              data=cer,               units='micron')
             self.data['cwp']      = dict(name='Cloud water path',                    data=cwp,               units='g/m^2')
-            self.data['ctp_uct']  = dict(name='Cloud top pressure uncertainty',      data=ctp*ctp_uct/100.0, units='mb')
-            self.data['cth_uct']  = dict(name='Cloud top height uncertainty',        data=cth*cth_uct/100.0, units='m')
             self.data['cot_uct']  = dict(name='Cloud optical thickness uncertainty', data=cot*cot_uct/100.0, units='N/A')
             self.data['cer_uct']  = dict(name='Cloud effective radius uncertainty',  data=cer*cer_uct/100.0, units='micron')
-            self.data['cer_uct']  = dict(name='Cloud water path uncertainty',        data=cwp*cwp_uct/100.0, units='g/m^2')
+            self.data['cwp_uct']  = dict(name='Cloud water path uncertainty',        data=cwp*cwp_uct/100.0, units='g/m^2')
             self.data['pcl']      = dict(name='PCL tag (1:PCL, 0:Cloudy)',           data=pcl,               units='N/A')
             
 


### PR DESCRIPTION
This PR is mostly to fix major bugs with recently changed readers for MODIS and VIIRS. Also fixes the input argument for VIIRS cloud properties product download via `sdown`. This PR will likely be the last one before `sdown` is modified to develop its own workflow as it grows in size.