### PR TITLE
Fix bugs with PR #23 and other minor changes

### DIFF
--- a/docs/source/tutorial/tool.rst
+++ b/docs/source/tutorial/tool.rst
@@ -94,14 +94,14 @@ Satellite Products Download Tool - ``sdown``
   LAADS DAAC and LANCE, and satellite RGB imageries from NASA WorldView) for a user specified
   date and region. The development of ``sdown`` is led by Vikas Nataraja.
 
-  Setup may be required to start using ``sdown``: 
+  Setup may be required to start using ``sdown``:
 
   .. code-block:: bash
 
     python setup.py develop
 
   Once setup, sdown should be available via Terminal. To test if setup is correct, use:
-  
+
   .. code-block:: bash
 
     sdown --run_demo
@@ -116,38 +116,38 @@ Satellite Products Download Tool - ``sdown``
     sdown --date 20230326 --lons 127 132 --lats -14 -10 --products mod021km vnp02mod modrgb vnprgb --verbose
 
   The following command line arguments are available to customize (use ``sdown --help`` to view all options in detail):
-  
+
   .. code-block:: bash
-    
+
     -f , --fdir           Directory where the files will be downloaded
                           By default, files will be downloaded to 'sat-data/'
-                          
+
     -v, --verbose         Pass --verbose if status of your request should be reported frequently.
 
     -d , --date           Date for which you would like to download data. Use yyyymmdd format.
                           Example: --date 20210404
-                          
+
     -t , --start_date     The start date of the range of dates for which you would like to download data. Use yyyymmdd format.
                           Example: --start_date 20210404
-                          
+
     -u , --end_date       The end date of the range of dates for which you would like to download data. Use yyyymmdd format.
                           Example: --end_date 20210414
-                          
+
     -e  [ ...], --extent  [ ...]
-                          Extent of region of interest 
+                          Extent of region of interest
                           lon1 lon2 lat1 lat2 in West East South North format.
                           Example:  --extent -10 -5 25 30
-                          
+
     -x  [ ...], --lons  [ ...]
                           The west-most and east-most longitudes of the region.
                           Alternative to providing the first two terms in `extent`.
                           Example:  --lons -10 -5
-                          
+
     -y  [ ...], --lats  [ ...]
                           The south-most and north-most latitudes of the region.
                           Alternative to providing the last two terms in `extent`.
                           Example:  --lats 25 30
-                          
+
     -n, --nrt             Pass --nrt if Near Real Time products should be downloaded.
                           This is disabled by default to automatically download standard products.
                           Currently, only MODIS NRT products can be downloaded.
@@ -155,7 +155,7 @@ Satellite Products Download Tool - ``sdown``
                           Short prefix (case insensitive) for the product name.
                           Example:  --products MOD02QKM
 
-  
+
   We currently support the download of the following products:
 
   .. code-block:: bash
@@ -190,8 +190,8 @@ Satellite Products Download Tool - ``sdown``
 
   We are working on supporting more products via this tool.
 
-  
-  
+
+
 
 
 

--- a/docs/source/tutorial/tool.rst
+++ b/docs/source/tutorial/tool.rst
@@ -87,9 +87,112 @@ Data Tool - ``lsa``
 
 |
 
-Satellite Tool - ``sdown``
---------------------------
+Satellite Products Download Tool - ``sdown``
+--------------------------------------------
 
   This tool can be used to effortlessly download satellite data (currently supports MODIS and VIIRS data archived on
   LAADS DAAC and LANCE, and satellite RGB imageries from NASA WorldView) for a user specified
   date and region. The development of ``sdown`` is led by Vikas Nataraja.
+
+  Setup may be required to start using ``sdown``: 
+
+  .. code-block:: bash
+
+    python setup.py develop
+
+  Once setup, sdown should be available via Terminal. To test if setup is correct, use:
+  
+  .. code-block:: bash
+
+    sdown --run_demo
+
+  The command above should download sample product files from the LAADS DAAC servers and store them in a directory called ``sat-data/``.
+
+  Example Usage:
+  To download MODIS-Terra and VIIRS-SNPP L1b products and a Worldview RGB image near Papua New Guinea/north Western Australia for March 26, 2023:
+
+  .. code-block:: bash
+
+    sdown --date 20230326 --lons 127 132 --lats -14 -10 --products mod021km vnp02mod modrgb vnprgb --verbose
+
+  The following command line arguments are available to customize (use ``sdown --help`` to view all options in detail):
+  
+  .. code-block:: bash
+    
+    -f , --fdir           Directory where the files will be downloaded
+                          By default, files will be downloaded to 'sat-data/'
+                          
+    -v, --verbose         Pass --verbose if status of your request should be reported frequently.
+
+    -d , --date           Date for which you would like to download data. Use yyyymmdd format.
+                          Example: --date 20210404
+                          
+    -t , --start_date     The start date of the range of dates for which you would like to download data. Use yyyymmdd format.
+                          Example: --start_date 20210404
+                          
+    -u , --end_date       The end date of the range of dates for which you would like to download data. Use yyyymmdd format.
+                          Example: --end_date 20210414
+                          
+    -e  [ ...], --extent  [ ...]
+                          Extent of region of interest 
+                          lon1 lon2 lat1 lat2 in West East South North format.
+                          Example:  --extent -10 -5 25 30
+                          
+    -x  [ ...], --lons  [ ...]
+                          The west-most and east-most longitudes of the region.
+                          Alternative to providing the first two terms in `extent`.
+                          Example:  --lons -10 -5
+                          
+    -y  [ ...], --lats  [ ...]
+                          The south-most and north-most latitudes of the region.
+                          Alternative to providing the last two terms in `extent`.
+                          Example:  --lats 25 30
+                          
+    -n, --nrt             Pass --nrt if Near Real Time products should be downloaded.
+                          This is disabled by default to automatically download standard products.
+                          Currently, only MODIS NRT products can be downloaded.
+    -p  [ ...], --products  [ ...]
+                          Short prefix (case insensitive) for the product name.
+                          Example:  --products MOD02QKM
+
+  
+  We currently support the download of the following products:
+
+  .. code-block:: bash
+
+    MOD02QKM:  Level 1b 250m (Terra) radiance product
+    MYD02QKM:  Level 1b 250m (Aqua)  radiance product
+    MOD02HKM:  Level 1b 500m (Terra) radiance product
+    MYD02HKM:  Level 1b 500m (Aqua)  radiance product
+    MOD021KM:  Level 1b 1km (Terra)  radiance product
+    MYD021KM:  Level 1b 1km (Aqua)   radiance product
+    MOD06_L2:  Level 2 (Terra) cloud product
+    MYD06_L2:  Level 2 (Aqua)  cloud product
+    MOD35_L2:  Level 2 (Terra) cloud mask product
+    MYD35_L2:  Level 2 (Aqua)  cloud mask product
+    MOD03   :  Solar/viewing geometry (Terra) product
+    MYD03   :  Solar/viewing geometry (Aqua)  product
+    MODRGB  :  True-Color RGB (Terra) imagery, useful for visuzliation
+    MYDRGB  :  True-Color RGB (Aqua)  imagery, useful for visuzliation
+    MCD43   :  Level 3 surface product MCD43A3
+    VNPRGB  :  True-Color RGB (S-NPP) imagery, useful for visuzliation
+    VJ1RGB  :  True-Color RGB (NOAA-20) imagery, useful for visuzliation
+    VNP02IMG:  Level 1b 375m (S-NPP) radiance product
+    VJ102IMG:  Level 1b 375m (NOAA-20) radiance product
+    VNP03IMG:  Solar/viewing geometry 375m (S-NPP) product
+    VJ103IMG:  Solar/viewing geometry 375m (NOAA-20) product
+    VNP02MOD:  Level 1b 750m (S-NPP) radiance product
+    VJ102MOD:  Level 1b 750m (NOAA-20) radiance product
+    VNP03MOD:  Solar/viewing geometry 750m (S-NPP) product
+    VJ103MOD:  Solar/viewing geometry 750m (NOAA-20) product
+    VNP_CLDPROP_L2: Level 2 (S-NPP) cloud properties product
+    VJ1_CLDPROP_L2: Level 2 (NOAA-20) cloud properties product
+
+  We are working on supporting more products via this tool.
+
+  
+  
+
+
+
+

--- a/er3t/util/modis.py
+++ b/er3t/util/modis.py
@@ -32,6 +32,7 @@ MODIS_L1B_HKM_1KM_BANDS = {
                         7: 2130
                       }
 
+
 # reader for MODIS (Moderate Resolution Imaging Spectroradiometer)
 #/-----------------------------------------------------------------------------\
 
@@ -80,7 +81,7 @@ class modis_l1b:
             if bands is None:
                 self.bands = list(MODIS_L1B_QKM_BANDS.keys())
             
-            elif (bands is not None) and (set(bands).issubset(set(MODIS_L1B_QKM_BANDS.keys()))):
+            elif (bands is not None) and not (set(bands).issubset(set(MODIS_L1B_QKM_BANDS.keys()))):
                 msg = 'Error [modis_l1b]: Bands must be one or more of %s' % list(MODIS_L1B_QKM_BANDS.keys())
                 raise KeyError(msg)
                                 
@@ -89,7 +90,7 @@ class modis_l1b:
             if bands is None:
                 self.bands = list(MODIS_L1B_HKM_1KM_BANDS.keys())
             
-            elif (bands is not None) and (set(bands).issubset(set(MODIS_L1B_HKM_1KM_BANDS.keys()))):
+            elif (bands is not None) and not (set(bands).issubset(set(MODIS_L1B_HKM_1KM_BANDS.keys()))):
                 msg = 'Error [modis_l1b]: Bands must be one or more of %s' % list(MODIS_L1B_HKM_1KM_BANDS.keys())
                 raise KeyError(msg)
                 
@@ -98,7 +99,7 @@ class modis_l1b:
             if bands is None:
                 self.bands = list(MODIS_L1B_HKM_1KM_BANDS.keys())
             
-            elif (bands is not None) and (set(bands).issubset(set(MODIS_L1B_HKM_1KM_BANDS.keys()))):
+            elif (bands is not None) and not (set(bands).issubset(set(MODIS_L1B_HKM_1KM_BANDS.keys()))):
                 msg = 'Error [modis_l1b]: Bands must be one or more of %s' % list(MODIS_L1B_HKM_1KM_BANDS.keys())
                 raise KeyError(msg)
                 
@@ -278,26 +279,26 @@ class modis_l1b:
         # Calculate 1. radiance, 2. reflectance, 3. corrected counts from the raw data
         #/----------------------------------------------------------------------------\#
         raw = raw0[:][:, logic]
-        rad = np.zeros(raw.shape, dtype=np.float64)
-        ref = np.zeros(raw.shape, dtype=np.float64)
-        cnt = np.zeros(raw.shape, dtype=np.float64)
+        rad = np.zeros((len(self.bands), raw.shape[1]), dtype=np.float64)
+        ref = np.zeros((len(self.bands), raw.shape[1]), dtype=np.float64)
+        cnt = np.zeros((len(self.bands), raw.shape[1]), dtype=np.float64)
 
         # Calculate uncertainty
         uct     = uct0[:][:, logic]
-        uct_pct = np.zeros(uct.shape, dtype=np.float64)
+        uct_pct = np.zeros((len(self.bands), raw.shape[1]), dtype=np.float64)
         
         wvl = np.zeros(len(self.bands), dtype='uint16')
 
         band_counter = 0
-        for i in range(raw.shape[0]):
-            if list(MODIS_L1B_HKM_1KM_BANDS.keys())[i] in self.bands: # only get the required bands
-                rad0                         = (raw[i, ...] - rad_off[i]) * rad_sca[i]
-                rad[band_counter, ...]       = rad0/1000.0 # convert to W/m^2/nm/sr
-                ref[band_counter, ...]       = (raw[i, ...] - ref_off[i]) * ref_sca[i]
-                cnt[band_counter, ...]       = (raw[i, ...] - cnt_off[i]) * cnt_sca[i]
-                uct_pct[band_counter, ...]   = uct_spc[i] * np.exp(uct[i] / uct_sca[i]) # convert to percentage
-                wvl[band_counter]            = MODIS_L1B_HKM_1KM_BANDS[self.bands[band_counter]]
-                band_counter                += 1
+        for i in self.bands:
+            band_idx                     = i - 1 # band indexing in Python starts from 0
+            rad0                         = (raw[band_idx, ...] - rad_off[band_idx]) * rad_sca[band_idx]
+            rad[band_counter, ...]       = rad0/1000.0 # convert to W/m^2/nm/sr
+            ref[band_counter, ...]       = (raw[band_idx, ...] - ref_off[band_idx]) * ref_sca[band_idx]
+            cnt[band_counter, ...]       = (raw[band_idx, ...] - cnt_off[band_idx]) * cnt_sca[band_idx]
+            uct_pct[band_counter, ...]   = uct_spc[band_idx] * np.exp(uct[band_idx] / uct_sca[band_idx]) # convert to percentage
+            wvl[band_counter]            = MODIS_L1B_HKM_1KM_BANDS[self.bands[band_counter]]
+            band_counter                += 1
             
         f.end()
         # -------------------------------------------------------------------------------------------------

--- a/er3t/util/modis.py
+++ b/er3t/util/modis.py
@@ -16,19 +16,19 @@ __all__ = ['modis_l1b', 'modis_l2', 'modis_35_l2', 'modis_03', 'modis_04', 'modi
 
 
 
-MODIS_L1B_QKM_BANDS = {    
-                        1: 650, 
+MODIS_L1B_QKM_BANDS = {
+                        1: 650,
                         2: 860,
                       }
 
 
-MODIS_L1B_HKM_1KM_BANDS = {    
-                        1: 650, 
+MODIS_L1B_HKM_1KM_BANDS = {
+                        1: 650,
                         2: 860,
-                        3: 470, 
-                        4: 555, 
-                        5: 1240, 
-                        6: 1640, 
+                        3: 470,
+                        4: 555,
+                        5: 1240,
+                        6: 1640,
                         7: 2130
                       }
 
@@ -80,29 +80,29 @@ class modis_l1b:
             self.resolution = 0.25
             if bands is None:
                 self.bands = list(MODIS_L1B_QKM_BANDS.keys())
-            
+
             elif (bands is not None) and not (set(bands).issubset(set(MODIS_L1B_QKM_BANDS.keys()))):
                 msg = 'Error [modis_l1b]: Bands must be one or more of %s' % list(MODIS_L1B_QKM_BANDS.keys())
                 raise KeyError(msg)
-                                
+
         elif 'hkm' in filename:
             self.resolution = 0.5
             if bands is None:
                 self.bands = list(MODIS_L1B_HKM_1KM_BANDS.keys())
-            
+
             elif (bands is not None) and not (set(bands).issubset(set(MODIS_L1B_HKM_1KM_BANDS.keys()))):
                 msg = 'Error [modis_l1b]: Bands must be one or more of %s' % list(MODIS_L1B_HKM_1KM_BANDS.keys())
                 raise KeyError(msg)
-                
+
         elif '1km' in filename:
             self.resolution = 1.0
             if bands is None:
                 self.bands = list(MODIS_L1B_HKM_1KM_BANDS.keys())
-            
+
             elif (bands is not None) and not (set(bands).issubset(set(MODIS_L1B_HKM_1KM_BANDS.keys()))):
                 msg = 'Error [modis_l1b]: Bands must be one or more of %s' % list(MODIS_L1B_HKM_1KM_BANDS.keys())
                 raise KeyError(msg)
-                
+
         else:
             sys.exit('Error [modis_l1b]: Currently, only QKM (0.25km), HKM (0.5km), and 1KM products are supported.')
 
@@ -118,7 +118,7 @@ class modis_l1b:
         cnt_off = hdf_dset_250.attributes()['corrected_counts_offsets'] + hdf_dset_500.attributes()['corrected_counts_offsets']
         cnt_sca = hdf_dset_250.attributes()['corrected_counts_scales']  + hdf_dset_500.attributes()['corrected_counts_scales']
         return rad_off, rad_sca, ref_off, ref_sca, cnt_off, cnt_sca
-        
+
 
     def _get_250_500_uct(self, hdf_uct_250, hdf_uct_500):
         uct_spc = hdf_uct_250.attributes()['specified_uncertainty'] + hdf_uct_500.attributes()['specified_uncertainty']
@@ -156,7 +156,7 @@ class modis_l1b:
             else:
                 lat0  = f.select('Latitude')
                 lon0  = f.select('Longitude')
-                
+
             lon, lat  = upscale_modis_lonlat(lon0[:], lat0[:], scale=4, extra_grid=False)
             raw0      = f.select('EV_250_RefSB')
             uct0      = f.select('EV_250_RefSB_Uncert_Indexes')
@@ -207,7 +207,7 @@ class modis_l1b:
             else:
                 lat0  = f.select('Latitude')
                 lon0  = f.select('Longitude')
-                
+
 
             lon, lat  = upscale_modis_lonlat(lon0[:], lat0[:], scale=2, extra_grid=False)
             raw0_250  = f.select('EV_250_Aggr500_RefSB')
@@ -286,7 +286,7 @@ class modis_l1b:
         # Calculate uncertainty
         uct     = uct0[:][:, logic]
         uct_pct = np.zeros((len(self.bands), raw.shape[1]), dtype=np.float64)
-        
+
         wvl = np.zeros(len(self.bands), dtype='uint16')
 
         band_counter = 0
@@ -299,7 +299,7 @@ class modis_l1b:
             uct_pct[band_counter, ...]   = uct_spc[band_idx] * np.exp(uct[band_idx] / uct_sca[band_idx]) # convert to percentage
             wvl[band_counter]            = MODIS_L1B_HKM_1KM_BANDS[self.bands[band_counter]]
             band_counter                += 1
-            
+
         f.end()
         # -------------------------------------------------------------------------------------------------
 

--- a/er3t/util/modis.py
+++ b/er3t/util/modis.py
@@ -15,29 +15,21 @@ __all__ = ['modis_l1b', 'modis_l2', 'modis_35_l2', 'modis_03', 'modis_04', 'modi
            'download_modis_rgb', 'download_modis_https', 'cal_sinusoidal_grid', 'get_sinusoidal_grid_tag']
 
 
-MODIS_L1B_1KM_BANDS = {    
-                        0: 650, 
-                        1: 860,
-                        2: 470, 
-                        3: 555, 
-                        4: 1240, 
-                        5: 1640, 
-                        6: 2130
-                      }
-
 
 MODIS_L1B_QKM_BANDS = {    
-                        0: 650, 
-                        1: 860,
+                        1: 650, 
+                        2: 860,
                       }
 
 
-MODIS_L1B_HKM_BANDS = {    
-                        2: 470, 
-                        3: 555, 
-                        4: 1240, 
-                        5: 1640, 
-                        6: 2130
+MODIS_L1B_HKM_1KM_BANDS = {    
+                        1: 650, 
+                        2: 860,
+                        3: 470, 
+                        4: 555, 
+                        5: 1240, 
+                        6: 1640, 
+                        7: 2130
                       }
 
 # reader for MODIS (Moderate Resolution Imaging Spectroradiometer)
@@ -95,19 +87,19 @@ class modis_l1b:
         elif 'hkm' in filename:
             self.resolution = 0.5
             if bands is None:
-                self.bands = list(MODIS_L1B_HKM_BANDS.keys())
+                self.bands = list(MODIS_L1B_HKM_1KM_BANDS.keys())
             
-            elif (bands is not None) and (set(bands).issubset(set(MODIS_L1B_HKM_BANDS.keys()))):
-                msg = 'Error [modis_l1b]: Bands must be one or more of %s' % list(MODIS_L1B_HKM_BANDS.keys())
+            elif (bands is not None) and (set(bands).issubset(set(MODIS_L1B_HKM_1KM_BANDS.keys()))):
+                msg = 'Error [modis_l1b]: Bands must be one or more of %s' % list(MODIS_L1B_HKM_1KM_BANDS.keys())
                 raise KeyError(msg)
                 
         elif '1km' in filename:
             self.resolution = 1.0
             if bands is None:
-                self.bands = list(MODIS_L1B_1KM_BANDS.keys())
+                self.bands = list(MODIS_L1B_HKM_1KM_BANDS.keys())
             
-            elif (bands is not None) and (set(bands).issubset(set(MODIS_L1B_1KM_BANDS.keys()))):
-                msg = 'Error [modis_l1b]: Bands must be one or more of %s' % list(MODIS_L1B_1KM_BANDS.keys())
+            elif (bands is not None) and (set(bands).issubset(set(MODIS_L1B_HKM_1KM_BANDS.keys()))):
+                msg = 'Error [modis_l1b]: Bands must be one or more of %s' % list(MODIS_L1B_HKM_1KM_BANDS.keys())
                 raise KeyError(msg)
                 
         else:
@@ -115,6 +107,22 @@ class modis_l1b:
 
         for fname in self.fnames:
             self.read(fname)
+
+
+    def _get_250_500_attrs(self, hdf_dset_250, hdf_dset_500):
+        rad_off = hdf_dset_250.attributes()['radiance_offsets']         + hdf_dset_500.attributes()['radiance_offsets']
+        rad_sca = hdf_dset_250.attributes()['radiance_scales']          + hdf_dset_500.attributes()['radiance_scales']
+        ref_off = hdf_dset_250.attributes()['reflectance_offsets']      + hdf_dset_500.attributes()['reflectance_offsets']
+        ref_sca = hdf_dset_250.attributes()['reflectance_scales']       + hdf_dset_500.attributes()['reflectance_scales']
+        cnt_off = hdf_dset_250.attributes()['corrected_counts_offsets'] + hdf_dset_500.attributes()['corrected_counts_offsets']
+        cnt_sca = hdf_dset_250.attributes()['corrected_counts_scales']  + hdf_dset_500.attributes()['corrected_counts_scales']
+        return rad_off, rad_sca, ref_off, ref_sca, cnt_off, cnt_sca
+        
+
+    def _get_250_500_uct(self, hdf_uct_250, hdf_uct_500):
+        uct_spc = hdf_uct_250.attributes()['specified_uncertainty'] + hdf_uct_500.attributes()['specified_uncertainty']
+        uct_sca = hdf_uct_250.attributes()['scaling_factor']        + hdf_uct_500.attributes()['scaling_factor']
+        return uct_spc, uct_sca
 
 
     def read(self, fname):
@@ -141,76 +149,34 @@ class modis_l1b:
 
         # when resolution equals to 250 m
         if check_equal(self.resolution, 0.25):
-            lat0      = f.select('Latitude')
-            lon0      = f.select('Longitude')
+            if self.f03 is not None:
+                lon0  = self.f03.data['lon']['data']
+                lat0  = self.f03.data['lat']['data']
+            else:
+                lat0  = f.select('Latitude')
+                lon0  = f.select('Longitude')
+                
             lon, lat  = upscale_modis_lonlat(lon0[:], lat0[:], scale=4, extra_grid=False)
             raw0      = f.select('EV_250_RefSB')
             uct0      = f.select('EV_250_RefSB_Uncert_Indexes')
-            wvl       = np.array([650, 860], dtype='uint16')
-            do_region = True
+            # wvl       = np.array([650, 860], dtype='uint16') # QKM bands
 
-        # when resolution equals to 500 m
-        elif check_equal(self.resolution, 0.5):
-            lat0      = f.select('Latitude')
-            lon0      = f.select('Longitude')
-            lon, lat  = upscale_modis_lonlat(lon0[:], lat0[:], scale=2, extra_grid=False)
-            raw0      = f.select('EV_500_RefSB')
-            uct0      = f.select('EV_500_RefSB_Uncert_Indexes')
-            wvl       = np.array([470, 555, 1240, 1640, 2130], dtype='uint16')
-            do_region = True
+            # if self.extent is None:
+            #     if 'actual_range' in lon0.attributes().keys():
+            #         lon_range = lon0.attributes()['actual_range']
+            #         lat_range = lat0.attributes()['actual_range']
+            #     elif 'valid_range' in lon0.attributes().keys():
+            #         lon_range = lon0.attributes()['valid_range']
+            #         lat_range = lat0.attributes()['valid_range']
+            #     else:
+            #         lon_range = [-180.0, 180.0]
+            #         lat_range = [-90.0 , 90.0]
 
-        # when resolution equals to 1000 m
-        elif check_equal(self.resolution, 1.0):
-            if self.f03 is not None:
-                raw0_250  = f.select('EV_250_Aggr1km_RefSB')
-                uct0_250  = f.select('EV_250_Aggr1km_RefSB_Uncert_Indexes')
-                raw0_500  = f.select('EV_500_Aggr1km_RefSB')
-                uct0_500  = f.select('EV_500_Aggr1km_RefSB_Uncert_Indexes')
-
-                # save offsets and scaling factors (from both visible and near infrared bands)
-                rad_off = raw0_250.attributes()['radiance_offsets'] + raw0_500.attributes()['radiance_offsets']
-                rad_sca = raw0_250.attributes()['radiance_scales'] + raw0_500.attributes()['radiance_scales']
-                ref_off = raw0_250.attributes()['reflectance_offsets'] + raw0_500.attributes()['reflectance_offsets']
-                ref_sca = raw0_250.attributes()['reflectance_scales'] + raw0_500.attributes()['reflectance_scales']
-                cnt_off = raw0_250.attributes()['corrected_counts_offsets'] + raw0_500.attributes()['corrected_counts_offsets']
-                cnt_sca = raw0_250.attributes()['corrected_counts_scales'] + raw0_500.attributes()['corrected_counts_scales']
-                uct_spc = uct0_250.attributes()['specified_uncertainty'] + uct0_500.attributes()['specified_uncertainty']
-                uct_sca = uct0_250.attributes()['scaling_factor'] + uct0_500.attributes()['scaling_factor']
-
-                # combine visible and near infrared bands
-                raw0      = np.vstack([raw0_250, raw0_500])
-                uct0      = np.vstack([uct0_250, uct0_500])
-                wvl       = np.array([650, 860, 470, 555, 1240, 1640, 2130], dtype='uint16')
-                do_region = False
-                lon       = self.f03.data['lon']['data']
-                lat       = self.f03.data['lat']['data']
-                logic     = self.f03.logic[find_fname_match(fname, self.f03.logic.keys())]['1km']
-            else:
-                sys.exit('Error   [modis_l1b]: \'resolution=%f\' has not been implemented without geolocation file being specified.' % self.resolution)
-
-        else:
-            sys.exit('Error   [modis_l1b]: \'resolution=%f\' has not been implemented.' % self.resolution)
-
-
-        # 1. If region (extent=) is specified, filter data within the specified region
-        # 2. If region (extent=) is not specified, filter invalid data
-        #/----------------------------------------------------------------------------\#
-
-        if do_region: # applied only for QKM (250m) or HKM (500m) products
             if self.extent is None:
-
-                if 'actual_range' in lon0.attributes().keys():
-                    lon_range = lon0.attributes()['actual_range']
-                    lat_range = lat0.attributes()['actual_range']
-                elif 'valid_range' in lon0.attributes().keys():
-                    lon_range = lon0.attributes()['valid_range']
-                    lat_range = lat0.attributes()['valid_range']
-                else:
-                    lon_range = [-180.0, 180.0]
-                    lat_range = [-90.0 , 90.0]
+                lon_range = [-180.0, 180.0]
+                lat_range = [-90.0 , 90.0]
 
             else:
-
                 lon_range = [self.extent[0] - 0.01, self.extent[1] + 0.01]
                 lat_range = [self.extent[2] - 0.01, self.extent[3] + 0.01]
 
@@ -230,7 +196,83 @@ class modis_l1b:
 
             uct_spc = uct0.attributes()['specified_uncertainty']
             uct_sca = uct0.attributes()['scaling_factor']
-        # -------------------------------------------------------------------------------------------------
+            do_region = True
+
+        # when resolution equals to 500 m
+        elif check_equal(self.resolution, 0.5):
+            if self.f03 is not None:
+                lon0  = self.f03.data['lon']['data']
+                lat0  = self.f03.data['lat']['data']
+            else:
+                lat0  = f.select('Latitude')
+                lon0  = f.select('Longitude')
+                
+
+            lon, lat  = upscale_modis_lonlat(lon0[:], lat0[:], scale=2, extra_grid=False)
+            raw0_250  = f.select('EV_250_Aggr500_RefSB')
+            uct0_250  = f.select('EV_250_Aggr500_RefSB_Uncert_Indexes')
+            raw0_500  = f.select('EV_500_RefSB')
+            uct0_500  = f.select('EV_500_RefSB_Uncert_Indexes')
+
+            # save offsets and scaling factors (from both QKM and HKM bands)
+            rad_off, rad_sca, ref_off, ref_sca, cnt_off, cnt_sca = self._get_250_500_attrs(raw0_250, raw0_500)
+            uct_spc, uct_sca                                     = self._get_250_500_uct(uct0_250, uct0_500)
+
+            # combine QKM and HKM bands
+            raw0      = np.vstack([raw0_250, raw0_500])
+            uct0      = np.vstack([uct0_250, uct0_500])
+
+            # wvl       = np.array([470, 555, 1240, 1640, 2130], dtype='uint16') # HKM bands
+            do_region = True
+
+            # if self.extent is None:
+            #     if 'actual_range' in lon0.attributes().keys():
+            #         lon_range = lon0.attributes()['actual_range']
+            #         lat_range = lat0.attributes()['actual_range']
+            #     elif 'valid_range' in lon0.attributes().keys():
+            #         lon_range = lon0.attributes()['valid_range']
+            #         lat_range = lat0.attributes()['valid_range']
+            #     else:
+            #         lon_range = [-180.0, 180.0]
+            #         lat_range = [-90.0 , 90.0]
+
+            if self.extent is None:
+                lon_range = [-180.0, 180.0]
+                lat_range = [-90.0 , 90.0]
+
+            else:
+                lon_range = [self.extent[0] - 0.01, self.extent[1] + 0.01]
+                lat_range = [self.extent[2] - 0.01, self.extent[3] + 0.01]
+
+            logic     = (lon >= lon_range[0]) & (lon <= lon_range[1]) & (lat >= lat_range[0]) & (lat <= lat_range[1])
+            lon       = lon[logic]
+            lat       = lat[logic]
+
+        # when resolution equals to 1000 m
+        elif check_equal(self.resolution, 1.0):
+            if self.f03 is not None:
+                raw0_250  = f.select('EV_250_Aggr1km_RefSB')
+                uct0_250  = f.select('EV_250_Aggr1km_RefSB_Uncert_Indexes')
+                raw0_500  = f.select('EV_500_Aggr1km_RefSB')
+                uct0_500  = f.select('EV_500_Aggr1km_RefSB_Uncert_Indexes')
+
+                # save offsets and scaling factors (from both QKM and HKM bands)
+                rad_off, rad_sca, ref_off, ref_sca, cnt_off, cnt_sca = self._get_250_500_attrs(raw0_250, raw0_500)
+                uct_spc, uct_sca                                     = self._get_250_500_uct(uct0_250, uct0_500)
+
+                # combine QKM and HKM bands
+                raw0      = np.vstack([raw0_250, raw0_500])
+                uct0      = np.vstack([uct0_250, uct0_500])
+                # wvl       = np.array([650, 860, 470, 555, 1240, 1640, 2130], dtype='uint16')
+                do_region = False
+                lon       = self.f03.data['lon']['data']
+                lat       = self.f03.data['lat']['data']
+                logic     = self.f03.logic[find_fname_match(fname, self.f03.logic.keys())]['1km']
+            else:
+                sys.exit('Error   [modis_l1b]: 1KM product reader has not been implemented without geolocation file being specified.')
+
+        else:
+            sys.exit('Error   [modis_l1b]: \'resolution=%f\' has not been implemented.' % self.resolution)
 
 
         # Calculate 1. radiance, 2. reflectance, 3. corrected counts from the raw data
@@ -246,14 +288,16 @@ class modis_l1b:
         
         wvl = np.zeros(len(self.bands), dtype='uint16')
 
-        for i in range(len(self.bands)):
-
-            rad0              = (raw[i, ...] - rad_off[i]) * rad_sca[i]
-            rad[i, ...]       = rad0/1000.0 # convert to W/m^2/nm/sr
-            ref[i, ...]       = (raw[i, ...] - ref_off[i]) * ref_sca[i]
-            cnt[i, ...]       = (raw[i, ...] - cnt_off[i]) * cnt_sca[i]
-            uct_pct[i, ...]   = uct_spc[i] * np.exp(uct[i] / uct_sca[i]) # convert to percentage
-            wvl[i]            = MODIS_L1B_1KM_BANDS[self.bands[i]]
+        band_counter = 0
+        for i in range(raw.shape[0]):
+            if list(MODIS_L1B_HKM_1KM_BANDS.keys())[i] in self.bands: # only get the required bands
+                rad0                         = (raw[i, ...] - rad_off[i]) * rad_sca[i]
+                rad[band_counter, ...]       = rad0/1000.0 # convert to W/m^2/nm/sr
+                ref[band_counter, ...]       = (raw[i, ...] - ref_off[i]) * ref_sca[i]
+                cnt[band_counter, ...]       = (raw[i, ...] - cnt_off[i]) * cnt_sca[i]
+                uct_pct[band_counter, ...]   = uct_spc[i] * np.exp(uct[i] / uct_sca[i]) # convert to percentage
+                wvl[band_counter]            = MODIS_L1B_HKM_1KM_BANDS[self.bands[band_counter]]
+                band_counter                += 1
             
         f.end()
         # -------------------------------------------------------------------------------------------------
@@ -262,24 +306,25 @@ class modis_l1b:
 
         if hasattr(self, 'data'):
             if do_region:
-                self.data['lon'] = dict(name='Longitude'           , data=np.hstack((self.data['lon']['data'], lon)), units='degrees')
-                self.data['lat'] = dict(name='Latitude'            , data=np.hstack((self.data['lat']['data'], lat)), units='degrees')
+                self.data['lon'] = dict(name='Longitude'           , data=np.hstack((self.data['lon']['data'], lon)),     units='degrees')
+                self.data['lat'] = dict(name='Latitude'            , data=np.hstack((self.data['lat']['data'], lat)),     units='degrees')
 
-            self.data['rad'] = dict(name='Radiance'                , data=np.hstack((self.data['rad']['data'], rad)), units='W/m^2/nm/sr')
-            self.data['ref'] = dict(name='Reflectance (x cos(SZA))', data=np.hstack((self.data['ref']['data'], ref)), units='N/A')
-            self.data['cnt'] = dict(name='Corrected Counts'        , data=np.hstack((self.data['cnt']['data'], cnt)), units='N/A')
+            self.data['rad'] = dict(name='Radiance'                , data=np.hstack((self.data['rad']['data'], rad)),     units='W/m^2/nm/sr')
+            self.data['ref'] = dict(name='Reflectance (x cos(SZA))', data=np.hstack((self.data['ref']['data'], ref)),     units='N/A')
+            self.data['cnt'] = dict(name='Corrected Counts'        , data=np.hstack((self.data['cnt']['data'], cnt)),     units='N/A')
             self.data['uct'] = dict(name='Uncertainty Percentage'  , data=np.hstack((self.data['uct']['data'], uct_pct)), units='N/A')
 
         else:
 
             self.data = {}
-            self.data['lon'] = dict(name='Longitude'               , data=lon, units='degrees')
-            self.data['lat'] = dict(name='Latitude'                , data=lat, units='degrees')
-            self.data['wvl'] = dict(name='Wavelength'              , data=wvl, units='nm')
-            self.data['rad'] = dict(name='Radiance'                , data=rad, units='W/m^2/nm/sr')
-            self.data['ref'] = dict(name='Reflectance (x cos(SZA))', data=ref, units='N/A')
-            self.data['cnt'] = dict(name='Corrected Counts'        , data=cnt, units='N/A')
+            self.data['lon'] = dict(name='Longitude'               , data=lon,     units='degrees')
+            self.data['lat'] = dict(name='Latitude'                , data=lat,     units='degrees')
+            self.data['wvl'] = dict(name='Wavelength'              , data=wvl,     units='nm')
+            self.data['rad'] = dict(name='Radiance'                , data=rad,     units='W/m^2/nm/sr')
+            self.data['ref'] = dict(name='Reflectance (x cos(SZA))', data=ref,     units='N/A')
+            self.data['cnt'] = dict(name='Corrected Counts'        , data=cnt,     units='N/A')
             self.data['uct'] = dict(name='Uncertainty Percentage'  , data=uct_pct, units='N/A')
+
 
     def save_h5(self, fname):
 


### PR DESCRIPTION
This PR is being requested in large part due to bugs with previous PR #23.

- Fixes how bands are handled within L1b readers for MODIS and VIIRS
    - Users can now specify whatever order of bands and the reader will get data in that order

- Expands MODIS L1b reader to retrieve QKM bands alongside HKM bands when viewing HKM product files.
- Adds documentation to `sdown`