### PR TITLE
Support reading lwc out of the LES data

### DIFF
--- a/er3t/pre/cld/cld_les.py
+++ b/er3t/pre/cld/cld_les.py
@@ -225,6 +225,7 @@ class cld_les:
         self.lay['temperature'] = {'data':t_3d  , 'name':'Temperature (3D)'            , 'units':'K'}
         self.lay['extinction']  = {'data':ext_3d, 'name':'Extinction coefficients (3D)', 'units':'m^-1'}
         self.lay['cer']         = {'data':cer_3d, 'name':'Cloud effective radius (3D)' , 'units':'mm'}
+        self.lay['lwc']         = {'data':lwc_3d, 'name':'Liquid water content (3D)'   , 'units':'kg m^-3'}
         #\--------------------------------------------------------------/#
 
 


### PR DESCRIPTION
Just like extinction coefficient and cloud effective radius, this addition allows extraction of liquid water path, which can serve as an alternative retrievable parameter instead of cloud optical thickness.