### PR TITLE
Fix for scipy interpolation

### DIFF
--- a/er3t/util/modis.py
+++ b/er3t/util/modis.py
@@ -1694,7 +1694,6 @@ def upscale_modis_lonlat(lon_in, lat_in, scale=5, extra_grid=True):
     offsets = offsets_dict[scale]
 
     lon_in[lon_in>180.0] -= 360.0
-
     # +
     # find center lon, lat
     proj_lonlat = ccrs.PlateCarree()
@@ -1735,10 +1734,18 @@ def upscale_modis_lonlat(lon_in, lat_in, scale=5, extra_grid=True):
 
     YY = np.arange(y)
 
-    f_x = interpolate.interp2d(XX_in, YY_in, xy_in[:, :, 0], kind='linear', fill_value=None)
-    f_y = interpolate.interp2d(XX_in, YY_in, xy_in[:, :, 1], kind='linear', fill_value=None)
+    # Deprecated since Scipy v1.12
+    # f_x = interpolate.interp2d(XX_in, YY_in, xy_in[:, :, 0], kind='linear', fill_value=None)
+    # f_y = interpolate.interp2d(XX_in, YY_in, xy_in[:, :, 1], kind='linear', fill_value=None)
 
-    lonlat = proj_lonlat.transform_points(proj_xy, f_x(XX, YY), f_y(XX, YY))[:, :, [0, 1]]
+    XX_grid, YY_grid = np.meshgrid(XX, YY, indexing='ij')
+
+    # note that RegularGridInterpolator requires transposed data
+    f_x = interpolate.RegularGridInterpolator((XX_in, YY_in), xy_in[:, :, 0].T, method='linear', fill_value=None, bounds_error=False)
+    f_y = interpolate.RegularGridInterpolator((XX_in, YY_in), xy_in[:, :, 1].T, method='linear', fill_value=None, bounds_error=False)
+
+    # reverse the transpose to get back original form
+    lonlat = proj_lonlat.transform_points(proj_xy, f_x((XX_grid, YY_grid)).T, f_y((XX_grid, YY_grid)).T)[:, :, [0, 1]]
 
     return lonlat[:, :, 0], lonlat[:, :, 1]
 


### PR DESCRIPTION
Updates `scipy.interpolate.interp1d` which has been deprecated with a compatible function from `scipy`. The deprecation otherwise will throw an error