### PR TITLE
More readers for MODIS and VIIRS products and updated features for `sdown`

### DIFF
--- a/bin/sdown
+++ b/bin/sdown
@@ -49,7 +49,7 @@ import datetime
 import multiprocessing
 
 import er3t.util.daac
-import er3t.util
+import er3t.util.util
 import er3t.common
 from er3t.util.logger import Ear3tLogger
 
@@ -173,13 +173,13 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
                 sys.exit()
 
         elif geojson_fpath is not None:
-            lons0, lats0 = er3t.util.parse_geojson(geojson_fpath)
+            lons0, lats0 = er3t.util.util.parse_geojson(geojson_fpath)
             if (focus_extent[0] < np.nanmin(lons0)) or (focus_extent[1] > np.nanmax(lons0)) or (focus_extent[2] < np.nanmin(lats0)) or (focus_extent[3] > np.nanmax(lats0)):
                 satlogger.error('Error [sdown]: `focus_extent` coordinates {} must be within the coordinates provided in the geojson file {}'.format(focus_extent, geojson_fpath))
                 sys.exit()
 
 
-    llons, llats = er3t.util.region_parser(extent, lons, lats, geojson_fpath)
+    llons, llats = er3t.util.util.region_parser(extent, lons, lats, geojson_fpath)
 
     if not os.path.exists(fdir_out):
         os.makedirs(fdir_out)
@@ -187,11 +187,11 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
             satlogger.info('\nMessage [sdown]: Created %s. Files will be downloaded to this directory and structured by date\n' % fdir_out)
 
     # error handling for dates
-    if (date is None) and ((start_date is None) or (end_date is None)) and ((nrt) and (latest_nhours is None)):
-        satlogger.error('Error [sdown]: Please provide a date via --date or date range via --start_date and --end_date or --latest_nhours')
+    if (date is None) and ((start_date is None) or (end_date is None)) and ((nrt)):
+        satlogger.error('Error [sdown]: Please provide a date via --date or date range via --start_date and --end_date ')
         sys.exit()
 
-    elif (date is not None) and ((start_date is None) or (end_date is None)) and (latest_nhours is None):
+    elif (date is not None) and ((start_date is None) or (end_date is None)):
 
         start_dt_hhmm  = datetime.datetime(int(date[:4]), int(date[4:6]), int(date[6:8]), 0, 0)
         end_dt_hhmm    = datetime.datetime(int(date[:4]), int(date[4:6]), int(date[6:8]), 23, 59)
@@ -265,7 +265,7 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
 
 
     else:
-        if (start_date is not None) and (end_date is not None) and (latest_nhours is None):
+        if (start_date is not None) and (end_date is not None):
 
             # start at 0 UTC unless specified by user
             start_hr = 0
@@ -288,10 +288,6 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
             end_dt    = datetime.datetime(int(end_date[:4]), int(end_date[4:6]), int(end_date[6:8]), end_hr, end_min)
 
         else:
-            if nrt:
-                end_dt     = _today_dt
-                start_dt   = end_dt - datetime.timedelta(hours=latest_nhours)
-            else:
                 satlogger.error('Error [sdown]: Please provide a date via --date or date range via --start_date and --end_date or --latest_nhours. Note that --latest_nhours is only valid for near-real time data')
                 sys.exit()
 

--- a/bin/sdown
+++ b/bin/sdown
@@ -11,6 +11,7 @@ Now supports:
                 MOD021KM, MYD021KM
                 MOD06_L2, MYD06_L2
                 MOD35_L2, MYD35_L2
+                          MYD_CLDMSK_L2 (or Aqua_CLDMSK_L2)
                 MOD09,    MYD09
                 MCD43
 
@@ -20,6 +21,7 @@ Now supports:
                 VNP03MOD,       VJ103MOD,       VJ203MOD
                 VNP02MOD,       VJ102MOD,       VJ202MOD
                 VNP_CLDPROP_L2, VJ1_CLDPROP_L2
+                VNP_CLDMSK_L2,  VJ1_CLDMSK_L2,  VJ2_CLDMSK_L2
                 VNP09,          VJ109
 
     OCO-2 data: coming soon...
@@ -635,7 +637,7 @@ if __name__ == '__main__':
         lons       = None
         lats       = None
         fdir       = 'sat-data/'
-        products   = ['MODRGB', 'VNP02IMG']
+        products   = ['MOD06_L2', 'VNP02IMG']
         nrt        = False
         iou        = 0
         geojson    = None

--- a/bin/sdown
+++ b/bin/sdown
@@ -374,7 +374,7 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
                 satlogger.info("Message [sdown]: Found {} CPUs. Downloads will be spread over all available CPUs.".format(multiprocessing.cpu_count()))
             # start parallelization
             pool = multiprocessing.Pool(processes=multiprocessing.cpu_count())
-            pool.map(run, p_args)
+            pool.starmap(run, p_args)
             pool.close()
 
         else: # run as usual
@@ -571,6 +571,8 @@ def get_sat_info_from_product_tag(tag_):
 
 if __name__ == '__main__':
 
+    exec_start_dt = datetime.datetime.now() # to time sdown
+
     parser = ArgumentParser(prog='sdown', formatter_class=RawTextHelpFormatter,
                             description=_description_)
     parser.add_argument('--fdir', type=str, metavar='', default='sat-data/',
@@ -679,3 +681,8 @@ if __name__ == '__main__':
                                   products=args.products,
                                   parallel=args.parallel,
                                   verbose=args.verbose)
+
+        exec_stop_dt = datetime.datetime.now() # to time sdown
+        exec_total_time = exec_stop_dt - exec_start_dt
+        sdown_hrs, sdown_mins, sdown_secs, sdown_millisecs = er3t.util.util.format_time(exec_total_time.total_seconds())
+        print('\n\nTotal Execution Time: {}:{}:{}.{:0.2f}\n\n'.format(sdown_hrs, sdown_mins, sdown_secs, sdown_millisecs))

--- a/bin/sdown
+++ b/bin/sdown
@@ -11,6 +11,7 @@ Now supports:
                 MOD021KM, MYD021KM
                 MOD06_L2, MYD06_L2
                 MOD35_L2, MYD35_L2
+                MOD09,    MYD09
                 MCD43
 
     VIIRS data: VNPRGB,         VJ1RGB,         VJ2RGB,

--- a/bin/sdown
+++ b/bin/sdown
@@ -49,6 +49,7 @@ import datetime
 import multiprocessing
 
 import er3t.util.daac
+import er3t.util
 import er3t.common
 from er3t.util.logger import Ear3tLogger
 
@@ -135,7 +136,7 @@ def create_args_parallel(date_list,
     return arg_list
 
 
-def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out, nrt, iou, focus_extent, products, verbose, parallel):
+def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out, nrt, latest_nhours, iou, focus_extent, geojson_fpath, products, verbose):
 
 
     ########################################################################################################
@@ -156,24 +157,6 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
         viirs_noaa21 = list(filter(lambda x: x.upper().startswith('VJ2'), products))
 
 
-    if (extent is None) and ((lats is None) or (lons is None)):
-        satlogger.error('Error [sdown]: Must provide either extent or lon/lat coordinates')
-        sys.exit()
-
-    elif (extent is not None) and (len(extent) != 4) and ((lats is None) or (lons is None) or (len(lats) == 0) or (len(lons) == 0)):
-        satlogger.error('Error [sdown]: Must provide either extent with [lon1 lon2 lat1 lat2] or lon/lat coordinates via --lons and --lats')
-        sys.exit()
-
-    elif (extent is None) and (lats is not None) and (lons is not None) and ((len(lats) == 2) and (len(lons) == 2)) and (lons[0] < lons[1]) and (lats[0] < lats[1]):
-        extent = [lons[0], lons[1], lats[0], lats[1]]
-
-
-    # check to make sure extent is correct
-    if (extent[0] >= extent[1]) or (extent[2] >= extent[3]):
-        msg = 'Error [sdown]: The given extents of lon/lat are incorrect: %s.\nPlease check to make sure extent is passed as `lon1 lon2 lat1 lat2` format i.e. West, East, South, North.' % extent
-        satlogger.error(msg)
-        sys.exit()
-
     if focus_extent is not None:
         if len(focus_extent) != 4:
             satlogger.error('Error [sdown]: `focus_extent` must be in [lon1 lon2 lat1 lat2] format')
@@ -184,10 +167,19 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
                 satlogger.error('Error [sdown]: `focus_extent` coordinates {} must be within `extent` coordinates {}'.format(focus_extent, extent))
                 sys.exit()
 
-        if (lats is not None) and (lons is not None):
+        elif (lats is not None) and (lons is not None):
             if (focus_extent[0] < lons[0]) or (focus_extent[1] > lons[1]) or (focus_extent[2] < lats[2]) or (focus_extent[3] > lats[3]):
                 satlogger.error('Error [sdown]: `focus_extent` coordinates {} must be within the coordinates provided by `lats` {} and `lons` {}'.format(focus_extent, lats, lons))
                 sys.exit()
+
+        elif geojson_fpath is not None:
+            lons0, lats0 = er3t.util.parse_geojson(geojson_fpath)
+            if (focus_extent[0] < np.nanmin(lons0)) or (focus_extent[1] > np.nanmax(lons0)) or (focus_extent[2] < np.nanmin(lats0)) or (focus_extent[3] > np.nanmax(lats0)):
+                satlogger.error('Error [sdown]: `focus_extent` coordinates {} must be within the coordinates provided in the geojson file {}'.format(focus_extent, geojson_fpath))
+                sys.exit()
+
+
+    llons, llats = er3t.util.region_parser(extent, lons, lats, geojson_fpath)
 
     if not os.path.exists(fdir_out):
         os.makedirs(fdir_out)
@@ -195,17 +187,17 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
             satlogger.info('\nMessage [sdown]: Created %s. Files will be downloaded to this directory and structured by date\n' % fdir_out)
 
     # error handling for dates
-    if (date is None) and ((start_date is None) or (end_date is None)):
-        satlogger.error('Error [sdown]: Please provide a date via --date or date range via --start_date and --end_date')
+    if (date is None) and ((start_date is None) or (end_date is None)) and ((nrt) and (latest_nhours is None)):
+        satlogger.error('Error [sdown]: Please provide a date via --date or date range via --start_date and --end_date or --latest_nhours')
         sys.exit()
 
-    elif (date is not None) and ((start_date is None) or (end_date is None)):
+    elif (date is not None) and ((start_date is None) or (end_date is None)) and (latest_nhours is None):
 
         start_dt_hhmm  = datetime.datetime(int(date[:4]), int(date[4:6]), int(date[6:8]), 0, 0)
         end_dt_hhmm    = datetime.datetime(int(date[:4]), int(date[4:6]), int(date[6:8]), 23, 59)
         single_dt      = datetime.datetime(int(date[:4]), int(date[4:6]), int(date[6:8]))
 
-        if (datetime.timedelta((_today_dt - single_dt).days).days < 0):
+        if single_dt > end_dt_hhmm:
             msg = 'Error [sdown]: Provided date is in the future. Data will only be downloaded until today\'s date.' + \
                   '\n\nReceived date   : %s\nToday\'s date is : %s UTC' % (single_dt.strftime("%d %B, %Y"), _today_dt.strftime("%d %B, %Y: %H%M"))
             satlogger.error(msg)
@@ -248,21 +240,22 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
             msg = 'Message [sdown]: Data will be downloaded for %s' % single_dt.strftime("%d %B, %Y")
             satlogger.info(msg)
 
-        fdir_out_dt = os.path.join(fdir_out, single_dt.strftime('%Y_%m_%d')) # save files in dirs with dates specified
+        fdir_out_dt = os.path.join(fdir_out, single_dt.strftime('%Y-%m-%d')) # save files in dirs with dates specified
         if not os.path.exists(fdir_out_dt):
             os.makedirs(fdir_out_dt)
 
         with open(os.path.join(fdir_out_dt, "metadata.txt"), "w") as f:
             f.write("Date: {}\n".format(single_dt))
-            f.write("Extent: {}\n".format(extent))
+            f.write("Extent: {}\n".format([np.nanmin(llons), np.nanmax(llons), np.nanmin(llats), np.nanmax(llats)]))
 
         if verbose:
-            satlogger.info("Message [sdown]: Obtaining data for: {} over following region:\nWest: {}, East: {}, South: {}, North: {}".format(single_dt.strftime("%d %B, %Y"), extent[0], extent[1], extent[2], extent[3]))
+            satlogger.info("Message [sdown]: Obtaining data for: {} over following region:\nWest: {}, East: {}, South: {}, North: {}".format(single_dt.strftime("%d %B, %Y"), np.nanmin(llons), np.nanmax(llons), np.nanmin(llats), np.nanmax(llats)))
 
         run(date=single_dt,
             start_dt_hhmm=start_dt_hhmm,
             end_dt_hhmm=end_dt_hhmm,
-            extent=extent,
+            lons=llons,
+            lats=llats,
             fdir_out=fdir_out_dt,
             nrt=nrt,
             iou=iou,
@@ -271,43 +264,53 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
             verbose=verbose)
 
 
-    elif (start_date is not None) and (end_date is not None):
+    else:
+        if (start_date is not None) and (end_date is not None) and (latest_nhours is None):
 
-        # start at 0 UTC unless specified by user
-        start_hr = 0
-        start_min = 0
-        if len(start_date) == 12:
-            start_hr, start_min = int(start_date[8:10]), int(start_date[10:12])
+            # start at 0 UTC unless specified by user
+            start_hr = 0
+            start_min = 0
+            if len(start_date) == 12:
+                start_hr, start_min = int(start_date[8:10]), int(start_date[10:12])
 
-        # look for data until the last minute of the day
-        end_hr = 23
-        end_min = 59
-        if (len(end_date) == 12):
-            if (int(end_date[8:10]) < end_hr): # update only if different
-                end_hr = int(end_date[8:10])
+            # look for data until the last minute of the day
+            end_hr = 23
+            end_min = 59
+            if (len(end_date) == 12):
+                if (int(end_date[8:10]) < end_hr): # update only if different
+                    end_hr = int(end_date[8:10])
 
-            if (int(end_date[10:12]) < end_min):
-                end_min = int(end_date[10:12])
+                if (int(end_date[10:12]) < end_min):
+                    end_min = int(end_date[10:12])
 
 
-        start_dt  = datetime.datetime(int(start_date[:4]), int(start_date[4:6]), int(start_date[6:8]), start_hr, start_min)
-        end_dt    = datetime.datetime(int(end_date[:4]), int(end_date[4:6]), int(end_date[6:8]), end_hr, end_min)
+            start_dt  = datetime.datetime(int(start_date[:4]), int(start_date[4:6]), int(start_date[6:8]), start_hr, start_min)
+            end_dt    = datetime.datetime(int(end_date[:4]), int(end_date[4:6]), int(end_date[6:8]), end_hr, end_min)
 
-        if datetime.timedelta((end_dt - start_dt).days).days < 0:
+        else:
+            if nrt:
+                end_dt     = _today_dt
+                start_dt   = end_dt - datetime.timedelta(hours=latest_nhours)
+            else:
+                satlogger.error('Error [sdown]: Please provide a date via --date or date range via --start_date and --end_date or --latest_nhours. Note that --latest_nhours is only valid for near-real time data')
+                sys.exit()
+
+
+        if start_dt == end_dt:
             msg = 'Warning [sdown]: `end_date` %s UTC and `start_date` %s UTC are both the same' % (start_dt.strftime("%d %B, %Y: %H%M"), end_dt.strftime("%d %B, %Y: %H%M"))
-            satlogger.warning(msg)
+            satlogger.warn(msg)
 
 
-        if (datetime.timedelta((_today_dt - start_dt).days).days < 0):
+        if start_dt > _today_dt:
             msg = 'Error [sdown]: `start_date` cannot be in the future.' + \
                   '\n\nReceived start date: %s UTC \nToday\'s date is    : %s UTC' % (start_dt.strftime("%d %B, %Y: %H%M"), _today_dt.strftime("%d %B, %Y: %H%M"))
             satlogger.error(msg)
             sys.exit()
 
-        if (datetime.timedelta((_today_dt - end_dt).days).days < 0):
+        if end_dt > _today_dt:
             msg = 'Warning [sdown]: End date is in the future. Data will only be downloaded until today\'s date.' + \
                   '\n\nReceived end date: %s UTC\nToday\'s date is : %s UTC' % (end_dt.strftime("%d %B, %Y: %H%M"), _today_dt.strftime("%d %B, %Y: %H%M"))
-            satlogger.warning(msg)
+            satlogger.warn(msg)
             end_dt = _today_dt
 
         # NRT data is only available for the most recent ~ 7 days or so
@@ -351,7 +354,7 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
             msg = 'Message [sdown]: Data will be downloaded for dates beginning %s UTC to %s UTC' % (start_dt.strftime("%d %B, %Y: %H%M"), end_dt.strftime("%d %B, %Y: %H%M"))
             satlogger.info(msg)
 
-        date_list = [start_dt + datetime.timedelta(days=x) for x in range((end_dt - start_dt).days + 1)]
+        date_list = [start_dt.date() + datetime.timedelta(days=x) for x in range((end_dt.date() - start_dt.date()).days + 1)]
         if parallel:
             # Experimental: delegate dates for parallel computing
             msg = 'Warning [sdown]: Parallelization enabled. This is currently in experimental mode, downloads may fail.\n'

--- a/bin/sdown
+++ b/bin/sdown
@@ -46,7 +46,7 @@ import sys
 from argparse import ArgumentParser, RawTextHelpFormatter
 import numpy as np
 import datetime
-
+import multiprocessing
 
 import er3t.util.daac
 import er3t.common
@@ -450,6 +450,37 @@ _sat_tags_support_ = {
         }
 #\----------------------------------------------------------------------------/#
 
+def create_args_parallel(date_list,
+                         start_dt_hhmm,
+                         end_dt_hhmm,
+                         extent,
+                         fdir_out,
+                         nrt,
+                         iou,
+                         focus_extent,
+                         products,
+                         verbose):
+
+
+    arg_list = []
+    for i in range(len(date_list)):
+        mini_list = []
+
+        mini_list.append(date_list[i])
+        mini_list.append(start_dt_hhmm)
+        mini_list.append(end_dt_hhmm)
+        mini_list.append(extent)
+        mini_list.append(fdir_out)
+        mini_list.append(nrt)
+        mini_list.append(iou)
+        mini_list.append(focus_extent)
+        mini_list.append(products)
+        mini_list.append(verbose)
+
+        arg_list.append(mini_list)
+
+    return arg_list
+
 
 def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out, nrt, iou, focus_extent, products, verbose):
 
@@ -681,17 +712,22 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
             if verbose:
                 satlogger.info("Message [sdown]: Obtaining data for: {} over following region:\nWest: {}, East: {}, South: {}, North: {}".format(date_x.strftime('%Y_%m_%d'), extent[0], extent[1], extent[2], extent[3]))
 
+        # Experimental: delegate dates for parallel computing
+        p_args = create_args_parallel(date_list, start_dt, end_dt, extent, fdir_out_dt, nrt, iou, focus_extent, products, verbose)
 
-            run(date=date_x,
-                start_dt_hhmm=start_dt,
-                end_dt_hhmm=end_dt,
-                extent=extent,
-                fdir_out=fdir_out_dt,
-                nrt=nrt,
-                iou=iou,
-                focus_extent=focus_extent,
-                products=products,
-                verbose=verbose)
+        pool = multiprocessing.Pool(processes=multiprocessing.cpu_count())
+        pool.map(run, p_args)
+        pool.close()
+        # run(date=date_x,
+        #     start_dt_hhmm=start_dt,
+        #     end_dt_hhmm=end_dt,
+        #     extent=extent,
+        #     fdir_out=fdir_out_dt,
+        #     nrt=nrt,
+        #     iou=iou,
+        #     focus_extent=focus_extent,
+        #     products=products,
+        #     verbose=verbose)
 
 
 

--- a/bin/sdown
+++ b/bin/sdown
@@ -683,7 +683,7 @@ if __name__ == '__main__':
                                   parallel=args.parallel,
                                   verbose=args.verbose)
 
-        exec_stop_dt = datetime.datetime.now() # to time sdown
-        exec_total_time = exec_stop_dt - exec_start_dt
-        sdown_hrs, sdown_mins, sdown_secs, sdown_millisecs = er3t.util.util.format_time(exec_total_time.total_seconds())
-        print('\n\nTotal Execution Time: {}:{}:{}.{}\n\n'.format(sdown_hrs, sdown_mins, sdown_secs, sdown_millisecs))
+    exec_stop_dt = datetime.datetime.now() # to time sdown
+    exec_total_time = exec_stop_dt - exec_start_dt
+    sdown_hrs, sdown_mins, sdown_secs, sdown_millisecs = er3t.util.util.format_time(exec_total_time.total_seconds())
+    print('\n\nTotal Execution Time: {}:{}:{}.{}\n\n'.format(sdown_hrs, sdown_mins, sdown_secs, sdown_millisecs))

--- a/bin/sdown
+++ b/bin/sdown
@@ -90,7 +90,8 @@ _nrt_oldest_dt = _today_dt - datetime.timedelta(days=7)
 def create_args_parallel(date_list,
                          start_dt_hhmm,
                          end_dt_hhmm,
-                         extent,
+                         lons,
+                         lats,
                          fdir_out,
                          nrt,
                          iou,
@@ -104,7 +105,6 @@ def create_args_parallel(date_list,
         date_list (list): List of dates.
         start_dt_hhmm (str): Start time in HHMM format.
         end_dt_hhmm (str): End time in HHMM format.
-        extent (str): Extent of the data.
         fdir_out (str): Output directory.
         nrt (bool): Flag indicating if the data is near real-time.
         iou (float): Intersection over Union threshold.
@@ -123,7 +123,8 @@ def create_args_parallel(date_list,
         mini_list.append(date_list[i])
         mini_list.append(start_dt_hhmm)
         mini_list.append(end_dt_hhmm)
-        mini_list.append(extent)
+        mini_list.append(lons)
+        mini_list.append(lats)
         mini_list.append(fdir_out[i])
         mini_list.append(nrt)
         mini_list.append(iou)
@@ -369,7 +370,7 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
                     f.write('Date: {}\n'.format(date_x))
                     f.write('Extent: {}\n'.format(extent))
 
-            p_args = create_args_parallel(date_list, start_dt, end_dt, extent, fdir_out_dt_list, nrt, iou, focus_extent, products, verbose)
+            p_args = create_args_parallel(date_list, start_dt, end_dt, llons, llats, fdir_out_dt_list, nrt, iou, focus_extent, products, verbose)
             if verbose:
                 satlogger.info("Message [sdown]: Found {} CPUs. Downloads will be spread over all available CPUs.".format(multiprocessing.cpu_count()))
             # start parallelization

--- a/bin/sdown
+++ b/bin/sdown
@@ -124,7 +124,7 @@ def create_args_parallel(date_list,
         mini_list.append(start_dt_hhmm)
         mini_list.append(end_dt_hhmm)
         mini_list.append(extent)
-        mini_list.append(fdir_out)
+        mini_list.append(fdir_out[i])
         mini_list.append(nrt)
         mini_list.append(iou)
         mini_list.append(focus_extent)
@@ -357,20 +357,19 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
             satlogger.warning(msg)
 
             # need to create dirs and write metadata before
+            fdir_out_dt_list = []
             for date_x in date_list: # download products date by date
                 fdir_out_dt = os.path.join(fdir_out, date_x.strftime('%Y_%m_%d')) # save files in dirs with dates specified
                 if not os.path.exists(fdir_out_dt):
                     os.makedirs(fdir_out_dt)
 
+                fdir_out_dt_list.append(fdir_out_dt)
                 # Save metadata
                 with open(os.path.join(fdir_out_dt, "metadata.txt"), "w") as f:
                     f.write('Date: {}\n'.format(date_x))
                     f.write('Extent: {}\n'.format(extent))
 
-                if verbose:
-                    satlogger.info("Message [sdown]: Obtaining data for: {} over following region:\nWest: {}, East: {}, South: {}, North: {}".format(date_x.strftime('%Y_%m_%d'), extent[0], extent[1], extent[2], extent[3]))
-
-            p_args = create_args_parallel(date_list, start_dt, end_dt, extent, fdir_out_dt, nrt, iou, focus_extent, products, verbose)
+            p_args = create_args_parallel(date_list, start_dt, end_dt, extent, fdir_out_dt_list, nrt, iou, focus_extent, products, verbose)
             if verbose:
                 satlogger.info("Message [sdown]: Found {} CPUs. Downloads will be spread over all available CPUs.".format(multiprocessing.cpu_count()))
             # start parallelization

--- a/bin/sdown
+++ b/bin/sdown
@@ -685,4 +685,4 @@ if __name__ == '__main__':
         exec_stop_dt = datetime.datetime.now() # to time sdown
         exec_total_time = exec_stop_dt - exec_start_dt
         sdown_hrs, sdown_mins, sdown_secs, sdown_millisecs = er3t.util.util.format_time(exec_total_time.total_seconds())
-        print('\n\nTotal Execution Time: {}:{}:{}.{:0.2f}\n\n'.format(sdown_hrs, sdown_mins, sdown_secs, sdown_millisecs))
+        print('\n\nTotal Execution Time: {}:{}:{}.{}\n\n'.format(sdown_hrs, sdown_mins, sdown_secs, sdown_millisecs))

--- a/bin/sdown
+++ b/bin/sdown
@@ -498,12 +498,6 @@ def run(date, start_dt_hhmm, end_dt_hhmm, lons, lats, fdir_out, nrt, iou, focus_
                     fnames[product_info['dict_key']] += p_fnames
 
             else:
-                #TODO: Keep track of this to remove this if condition once the product goes online
-                if product.upper().startswith(('VJ2')):
-                    msg = 'Warning [sdown]: Standard (non near-real time) products are not available yet for VIIRS onboard NOAA-21\n'\
-                          'This is because geoMetaVIIRS data is still unavailable.\n'
-                    satlogger.warning(msg)
-                    continue
 
                 filename_tags_03 = er3t.util.daac.get_satfile_tag(date=date,
                                                                   start_dt_hhmm=start_dt_hhmm,

--- a/bin/sdown
+++ b/bin/sdown
@@ -136,7 +136,7 @@ def create_args_parallel(date_list,
     return arg_list
 
 
-def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out, nrt, latest_nhours, iou, focus_extent, geojson_fpath, products, verbose):
+def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out, nrt, latest_nhours, iou, focus_extent, geojson_fpath, products, verbose, parallel):
 
 
     ########################################################################################################

--- a/bin/sdown
+++ b/bin/sdown
@@ -295,7 +295,7 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
 
         if datetime.timedelta((end_dt - start_dt).days).days < 0:
             msg = 'Warning [sdown]: `end_date` %s UTC and `start_date` %s UTC are both the same' % (start_dt.strftime("%d %B, %Y: %H%M"), end_dt.strftime("%d %B, %Y: %H%M"))
-            satlogger.warn(msg)
+            satlogger.warning(msg)
 
 
         if (datetime.timedelta((_today_dt - start_dt).days).days < 0):
@@ -307,7 +307,7 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
         if (datetime.timedelta((_today_dt - end_dt).days).days < 0):
             msg = 'Warning [sdown]: End date is in the future. Data will only be downloaded until today\'s date.' + \
                   '\n\nReceived end date: %s UTC\nToday\'s date is : %s UTC' % (end_dt.strftime("%d %B, %Y: %H%M"), _today_dt.strftime("%d %B, %Y: %H%M"))
-            satlogger.warn(msg)
+            satlogger.warning(msg)
             end_dt = _today_dt
 
         # NRT data is only available for the most recent ~ 7 days or so
@@ -355,7 +355,7 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
         if parallel:
             # Experimental: delegate dates for parallel computing
             msg = 'Warning [sdown]: Parallelization enabled. This is currently in experimental mode, downloads may fail.\n'
-            satlogger.warn(msg)
+            satlogger.warning(msg)
 
             # need to create dirs and write metadata before
             for date_x in date_list: # download products date by date
@@ -462,7 +462,7 @@ def run(date, start_dt_hhmm, end_dt_hhmm, extent, fdir_out, nrt, iou, focus_exte
             if nrt:
                 if product.upper().endswith(('VNP_CLDPROP_L2', 'VJ1_CLDPROP_L2', 'VJ2_CLDPROP_L2')):
                     msg = 'Warning [sdown]: VIIRS cloud products are not available in near real time (NRT)'
-                    satlogger.warn(msg)
+                    satlogger.warning(msg)
                     continue
                 # sys.exit()
 
@@ -472,7 +472,7 @@ def run(date, start_dt_hhmm, end_dt_hhmm, extent, fdir_out, nrt, iou, focus_exte
                       'for faster generation of products and therefore may not be the same quality. '\
                       'For a complete breakdown of how NASA generates these NRT products, visit:\n'\
                       ' %s' % link_to_nrt
-                satlogger.warn(msg)
+                satlogger.warning(msg)
 
                 filename_tags_03 = er3t.util.daac.get_satfile_tag(date=date,
                                                                   start_dt_hhmm=start_dt_hhmm,
@@ -503,7 +503,7 @@ def run(date, start_dt_hhmm, end_dt_hhmm, extent, fdir_out, nrt, iou, focus_exte
                 if product.upper().startswith(('VJ2')):
                     msg = 'Warning [sdown]: Standard (non near-real time) products are not available yet for VIIRS onboard NOAA-21\n'\
                           'This is because geoMetaVIIRS data is still unavailable.\n'
-                    satlogger.warn(msg)
+                    satlogger.warning(msg)
                     continue
 
                 filename_tags_03 = er3t.util.daac.get_satfile_tag(date=date,

--- a/bin/sdown
+++ b/bin/sdown
@@ -939,24 +939,24 @@ if __name__ == '__main__':
 
     parser = ArgumentParser(prog='sdown', formatter_class=RawTextHelpFormatter,
                             description=_description_)
-    parser.add_argument('-f', '--fdir', type=str, metavar='', default='sat-data/',
+    parser.add_argument('--fdir', type=str, metavar='', default='sat-data/',
                         help='Directory where the files will be downloaded\n'\
                         'By default, files will be downloaded to \'sat-data/\'\n \n')
     parser.add_argument('-v', '--verbose', action='store_true',
                         help='Pass --verbose if status of your request should be reported frequently.\n \n'\
                         'This is disabled by default.\n \n')
-    parser.add_argument('-r', '--run_demo', action='store_true',
+    parser.add_argument('--run_demo', action='store_true',
                         help='Pass --run_demo if you would like to view a demonstration of this tool.\n \n')
     required = parser.add_argument_group('Required Arguments')
     required.add_argument('-d', '--date', type=str, metavar='', default=None,
                         help='Date for which you would like to download data. '\
                         'Use yyyymmdd format.\n'\
                         'Example: --date 20210404\n \n')
-    required.add_argument('-t', '--start_date', type=str, metavar='', default=None,
+    required.add_argument('--start_date', type=str, metavar='', default=None,
                         help='The start date of the range of dates for which you would like to download data. '\
                         'Use yyyymmdd or yyyymmddhhmm format.\n'\
                         'Example: --start_date 20210404\n \n')
-    required.add_argument('-u', '--end_date', type=str, metavar='', default=None,
+    required.add_argument('--end_date', type=str, metavar='', default=None,
                         help='The end date of the range of dates for which you would like to download data. '\
                         'Use yyyymmdd or yyyymmddhhmm format.\n'\
                         'Example: --end_date 20210414\n \n')
@@ -973,15 +973,15 @@ if __name__ == '__main__':
     required.add_argument('-y', '--lats', nargs='+', type=float, metavar='',
                         help='The south-most and north-most latitudes of the region.\nAlternative to providing the last two terms in `extent`.\n'\
                         'Example:  --lats 25 30\n \n')
-    required.add_argument('-a', '--focus_extent', nargs='+', type=float, metavar='',
+    required.add_argument('--focus_extent', nargs='+', type=float, metavar='',
                         help='Extent of a smaller focus region of interest \nlon1 lon2 lat1 lat2 in West East South North format.')
     required.add_argument('--parallel', action='store_true',
                         help='Pass --parallel to enable parallelization of downloads spread over multiple CPUs.\n')
-    required.add_argument('-n', '--nrt', action='store_true',
+    required.add_argument('--nrt', action='store_true',
                         help='Pass --nrt if Near Real Time products should be downloaded.\n'\
                              'This is disabled by default to automatically download standard products.\n'\
                              'Currently, only MODIS and VIIRS NRT products can be downloaded.\n')
-    required.add_argument('-p', '--products', type=str, nargs='+', metavar='',
+    required.add_argument('--products', type=str, nargs='+', metavar='',
                         help='Short prefix (case insensitive) for the product name.\n'\
                         'Example:  --products MOD02QKM\n'
                         '\nTo see a list of supported products, type --help.\n'\

--- a/bin/sdown
+++ b/bin/sdown
@@ -460,8 +460,25 @@ def create_args_parallel(date_list,
                          focus_extent,
                          products,
                          verbose):
+    """
+    Create a list of arguments for parallel processing.
 
+    Args:
+        date_list (list): List of dates.
+        start_dt_hhmm (str): Start time in HHMM format.
+        end_dt_hhmm (str): End time in HHMM format.
+        extent (str): Extent of the data.
+        fdir_out (str): Output directory.
+        nrt (bool): Flag indicating if the data is near real-time.
+        iou (float): Intersection over Union threshold.
+        focus_extent (str): Extent to focus on.
+        products (list): List of products.
+        verbose (bool): Flag indicating if verbose output is enabled.
 
+    Returns:
+        list: List of argument lists.
+
+    """
     arg_list = []
     for i in range(len(date_list)):
         mini_list = []
@@ -482,7 +499,7 @@ def create_args_parallel(date_list,
     return arg_list
 
 
-def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out, nrt, iou, focus_extent, products, verbose):
+def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out, nrt, iou, focus_extent, products, verbose, parallel):
 
 
     ########################################################################################################
@@ -699,36 +716,58 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
             satlogger.info(msg)
 
         date_list = [start_dt + datetime.timedelta(days=x) for x in range((end_dt - start_dt).days + 1)]
-        for date_x in date_list: # download products date by date
-            fdir_out_dt = os.path.join(fdir_out, date_x.strftime('%Y_%m_%d')) # save files in dirs with dates specified
-            if not os.path.exists(fdir_out_dt):
-                os.makedirs(fdir_out_dt)
+        if parallel:
+            # Experimental: delegate dates for parallel computing
+            msg = 'Warning [sdown]: Parallelization enabled. This is currently in experimental mode, downloads may fail.\n'
+            satlogger.warn(msg)
 
-            # Save metadata
-            with open(os.path.join(fdir_out_dt, "metadata.txt"), "w") as f:
-                f.write('Date: {}\n'.format(date_x))
-                f.write('Extent: {}\n'.format(extent))
+            # need to create dirs and write metadata before
+            for date_x in date_list: # download products date by date
+                fdir_out_dt = os.path.join(fdir_out, date_x.strftime('%Y_%m_%d')) # save files in dirs with dates specified
+                if not os.path.exists(fdir_out_dt):
+                    os.makedirs(fdir_out_dt)
 
+                # Save metadata
+                with open(os.path.join(fdir_out_dt, "metadata.txt"), "w") as f:
+                    f.write('Date: {}\n'.format(date_x))
+                    f.write('Extent: {}\n'.format(extent))
+
+                if verbose:
+                    satlogger.info("Message [sdown]: Obtaining data for: {} over following region:\nWest: {}, East: {}, South: {}, North: {}".format(date_x.strftime('%Y_%m_%d'), extent[0], extent[1], extent[2], extent[3]))
+
+            p_args = create_args_parallel(date_list, start_dt, end_dt, extent, fdir_out_dt, nrt, iou, focus_extent, products, verbose)
             if verbose:
-                satlogger.info("Message [sdown]: Obtaining data for: {} over following region:\nWest: {}, East: {}, South: {}, North: {}".format(date_x.strftime('%Y_%m_%d'), extent[0], extent[1], extent[2], extent[3]))
+                satlogger.info("Message [sdown]: Found {} CPUs. Downloads will be spread over all available CPUs.".format(multiprocessing.cpu_count()))
+            # start parallelization
+            pool = multiprocessing.Pool(processes=multiprocessing.cpu_count())
+            pool.map(run, p_args)
+            pool.close()
 
-        # Experimental: delegate dates for parallel computing
-        p_args = create_args_parallel(date_list, start_dt, end_dt, extent, fdir_out_dt, nrt, iou, focus_extent, products, verbose)
+        else: # run as usual
+            for date_x in date_list: # download products date by date
+                fdir_out_dt = os.path.join(fdir_out, date_x.strftime('%Y_%m_%d')) # save files in dirs with dates specified
+                if not os.path.exists(fdir_out_dt):
+                    os.makedirs(fdir_out_dt)
 
-        pool = multiprocessing.Pool(processes=multiprocessing.cpu_count())
-        pool.map(run, p_args)
-        pool.close()
-        # run(date=date_x,
-        #     start_dt_hhmm=start_dt,
-        #     end_dt_hhmm=end_dt,
-        #     extent=extent,
-        #     fdir_out=fdir_out_dt,
-        #     nrt=nrt,
-        #     iou=iou,
-        #     focus_extent=focus_extent,
-        #     products=products,
-        #     verbose=verbose)
+                # Save metadata
+                with open(os.path.join(fdir_out_dt, "metadata.txt"), "w") as f:
+                    f.write('Date: {}\n'.format(date_x))
+                    f.write('Extent: {}\n'.format(extent))
 
+                if verbose:
+                    satlogger.info("Message [sdown]: Obtaining data for: {} over following region:\nWest: {}, East: {}, South: {}, North: {}".format(date_x.strftime('%Y_%m_%d'), extent[0], extent[1], extent[2], extent[3]))
+
+
+                run(date=date_x,
+                    start_dt_hhmm=start_dt,
+                    end_dt_hhmm=end_dt,
+                    extent=extent,
+                    fdir_out=fdir_out_dt,
+                    nrt=nrt,
+                    iou=iou,
+                    focus_extent=focus_extent,
+                    products=products,
+                    verbose=verbose)
 
 
 
@@ -936,6 +975,8 @@ if __name__ == '__main__':
                         'Example:  --lats 25 30\n \n')
     required.add_argument('-a', '--focus_extent', nargs='+', type=float, metavar='',
                         help='Extent of a smaller focus region of interest \nlon1 lon2 lat1 lat2 in West East South North format.')
+    required.add_argument('--parallel', action='store_true',
+                        help='Pass --parallel to enable parallelization of downloads spread over multiple CPUs.\n')
     required.add_argument('-n', '--nrt', action='store_true',
                         help='Pass --nrt if Near Real Time products should be downloaded.\n'\
                              'This is disabled by default to automatically download standard products.\n'\
@@ -962,6 +1003,7 @@ if __name__ == '__main__':
         nrt        = False
         iou        = 0
         focus_extent = None
+        parallel   = False
         verbose    = 1
 
         # initialize logger
@@ -978,6 +1020,7 @@ if __name__ == '__main__':
                                   iou=iou,
                                   focus_extent=focus_extent,
                                   products=products,
+                                  parallel=parallel,
                                   verbose=verbose)
     else:
 
@@ -995,4 +1038,5 @@ if __name__ == '__main__':
                                   iou=args.iou,
                                   focus_extent=args.focus_extent,
                                   products=args.products,
+                                  parallel=args.parallel,
                                   verbose=args.verbose)

--- a/bin/sdown
+++ b/bin/sdown
@@ -459,7 +459,7 @@ def run(date, start_dt_hhmm, end_dt_hhmm, lons, lats, fdir_out, nrt, iou, focus_
                 fnames[product_info['dict_key']] += p_fnames
 
         # MODIS Level-1b radiances, Level-2 cloud products, and solar/viewing geoemetries
-        elif product.upper().endswith(('QKM', 'HKM', '1KM', 'L2', '03', '02IMG', '02MOD', '03IMG', '03MOD', 'VNP_CLDPROP_L2', 'VJ1_CLDPROP_L2', 'VJ2_CLDPROP_L2')):
+        elif product.upper().endswith(('QKM', 'HKM', '1KM', 'L2', '03', '09', '02IMG', '02MOD', '03IMG', '03MOD', 'VNP_CLDPROP_L2', 'VJ1_CLDPROP_L2', 'VJ2_CLDPROP_L2')):
             if nrt:
                 if product.upper().endswith(('VNP_CLDPROP_L2', 'VJ1_CLDPROP_L2', 'VJ2_CLDPROP_L2')):
                     msg = 'Warning [sdown]: VIIRS cloud products are not available in near real time (NRT)'

--- a/bin/sdown
+++ b/bin/sdown
@@ -947,41 +947,40 @@ if __name__ == '__main__':
                         'This is disabled by default.\n \n')
     parser.add_argument('--run_demo', action='store_true',
                         help='Pass --run_demo if you would like to view a demonstration of this tool.\n \n')
-    required = parser.add_argument_group('Required Arguments')
-    required.add_argument('-d', '--date', type=str, metavar='', default=None,
+    parser.add_argument('-d', '--date', type=str, metavar='', default=None,
                         help='Date for which you would like to download data. '\
                         'Use yyyymmdd format.\n'\
                         'Example: --date 20210404\n \n')
-    required.add_argument('--start_date', type=str, metavar='', default=None,
+    parser.add_argument('--start_date', type=str, metavar='', default=None,
                         help='The start date of the range of dates for which you would like to download data. '\
                         'Use yyyymmdd or yyyymmddhhmm format.\n'\
                         'Example: --start_date 20210404\n \n')
-    required.add_argument('--end_date', type=str, metavar='', default=None,
+    parser.add_argument('--end_date', type=str, metavar='', default=None,
                         help='The end date of the range of dates for which you would like to download data. '\
                         'Use yyyymmdd or yyyymmddhhmm format.\n'\
                         'Example: --end_date 20210414\n \n')
-    required.add_argument('--iou', type=int, metavar='', default=0,
+    parser.add_argument('--iou', type=int, metavar='', default=0,
                         help='Percentage of points within the region of interest that must overlap with the satellite granule. \n'\
                         'If the overlap < iou, then the granule file will not be downloaded.\n'\
                         'Example:  --iou 60\n \n')
-    required.add_argument('-e', '--extent', nargs='+', type=float, metavar='',
+    parser.add_argument('-e', '--extent', nargs='+', type=float, metavar='',
                         help='Extent of region of interest \nlon1 lon2 lat1 lat2 in West East South North format.\n'\
                         'Example:  --extent -10 -5 25 30\n \n')
-    required.add_argument('-x', '--lons', nargs='+', type=float, metavar='',
+    parser.add_argument('-x', '--lons', nargs='+', type=float, metavar='',
                         help='The west-most and east-most longitudes of the region.\nAlternative to providing the first two terms in `extent`.\n'\
                         'Example:  --lons -10 -5\n \n')
-    required.add_argument('-y', '--lats', nargs='+', type=float, metavar='',
+    parser.add_argument('-y', '--lats', nargs='+', type=float, metavar='',
                         help='The south-most and north-most latitudes of the region.\nAlternative to providing the last two terms in `extent`.\n'\
                         'Example:  --lats 25 30\n \n')
-    required.add_argument('--focus_extent', nargs='+', type=float, metavar='',
+    parser.add_argument('--focus_extent', nargs='+', type=float, metavar='',
                         help='Extent of a smaller focus region of interest \nlon1 lon2 lat1 lat2 in West East South North format.')
-    required.add_argument('--parallel', action='store_true',
+    parser.add_argument('--parallel', action='store_true',
                         help='Pass --parallel to enable parallelization of downloads spread over multiple CPUs.\n')
-    required.add_argument('--nrt', action='store_true',
+    parser.add_argument('--nrt', action='store_true',
                         help='Pass --nrt if Near Real Time products should be downloaded.\n'\
                              'This is disabled by default to automatically download standard products.\n'\
                              'Currently, only MODIS and VIIRS NRT products can be downloaded.\n')
-    required.add_argument('--products', type=str, nargs='+', metavar='',
+    parser.add_argument('--products', type=str, nargs='+', metavar='',
                         help='Short prefix (case insensitive) for the product name.\n'\
                         'Example:  --products MOD02QKM\n'
                         '\nTo see a list of supported products, type --help.\n'\

--- a/bin/sdown
+++ b/bin/sdown
@@ -745,8 +745,10 @@ def run(date, start_dt_hhmm, end_dt_hhmm, extent, fdir_out, nrt, iou, focus_exte
 
     references = []
     fnames = {}
+    download_counter = 0 # overall tracker for all products
     for product in products:
 
+        product_download_counter = 0 # update counter per product
         product_info = get_sat_info_from_product_tag(product)
         fnames[product_info['dict_key']] = []
 
@@ -763,11 +765,13 @@ def run(date, start_dt_hhmm, end_dt_hhmm, extent, fdir_out, nrt, iou, focus_exte
                                                                 instrument=product_info['instrument'],
                                                                 coastline=False)]
             fnames[product_info['dict_key']] += p_fnames
+            product_download_counter += 1 # update counter only by 1 since it is always a single RGB image per satellite per date
 
         # MODIS surface product
         elif '43' in product.upper():
             from er3t.util.modis import get_sinusoidal_grid_tag
             filename_tags_43 = get_sinusoidal_grid_tag(lon, lat)
+            product_download_counter += len(filename_tags_43) # update counter
 
             for filename_tag in filename_tags_43:
                 p_fnames = er3t.util.daac.download_laads_https(date=date,
@@ -805,6 +809,8 @@ def run(date, start_dt_hhmm, end_dt_hhmm, extent, fdir_out, nrt, iou, focus_exte
                                                                   percent0=iou,
                                                                   nrt=True)
 
+                product_download_counter += len(filename_tags_03) # update counter
+
                 if verbose:
                     satlogger.info('Message [sdown]: Found %s %s overpasses for %s\n' % (len(filename_tags_03), product_info['satellite'], date.strftime('%B %d, %Y')))
 
@@ -834,6 +840,9 @@ def run(date, start_dt_hhmm, end_dt_hhmm, extent, fdir_out, nrt, iou, focus_exte
                                                                   instrument=product_info['instrument'],
                                                                   percent0=iou,
                                                                   nrt=False)
+
+                product_download_counter += len(filename_tags_03) # update counter
+
                 if verbose:
                     satlogger.info('Message [sdown]: Found %s %s overpasses for %s\n' % (len(filename_tags_03), product_info['satellite'], date.strftime('%B %d, %Y')))
 
@@ -852,9 +861,17 @@ def run(date, start_dt_hhmm, end_dt_hhmm, extent, fdir_out, nrt, iou, focus_exte
             raise OSError()
 
         references.append(product_info['reference'])
+        download_counter += product_download_counter
+        if verbose:
+            satlogger.info('Message [sdown]: Downloaded {} files for {} ({} onboard {})'.format(product_download_counter, product_info['dataset_tag'], product_info['instrument'], product_info['satellite']))
 
-    satlogger.info('If you would like to cite the use of this data:\n\n%s' % '\n\n'.join(references))
-    satlogger.info('Message [sdown]: Finished downloading satellite files! You can find them in %s' % fdir_out)
+
+    if download_counter > 0:
+        satlogger.info('If you would like to cite the use of this data:\n\n%s' % '\n\n'.join(references))
+        satlogger.info('Message [sdown]: Finished downloading {} satellite files! You can find them in {}'.format(download_counter, fdir_out))
+
+    else: # could not find suitable downloads so no references needed
+        satlogger.info('Message [sdown]: No satellite files were found for the given parameters')
 
 
 def get_sat_info_from_product_tag(tag_):

--- a/bin/sdown
+++ b/bin/sdown
@@ -136,7 +136,7 @@ def create_args_parallel(date_list,
     return arg_list
 
 
-def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out, nrt, latest_nhours, iou, focus_extent, geojson_fpath, products, verbose, parallel):
+def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out, nrt, iou, focus_extent, geojson_fpath, products, verbose, parallel):
 
 
     ########################################################################################################
@@ -611,6 +611,9 @@ if __name__ == '__main__':
     parser.add_argument('-y', '--lats', nargs='+', type=float, metavar='',
                         help='The south-most and north-most latitudes of the region.\nAlternative to providing the last two terms in `extent`.\n'\
                         'Example:  --lats 25 30\n \n')
+    parser.add_argument('--geojson', type=str, metavar='',
+                        help='Path to a geoJSON file containing the extent of interest coordinates\n'\
+                        'Example:  --geojson my/path/to/geofile.json\n \n')
     parser.add_argument('--focus_extent', nargs='+', type=float, metavar='',
                         help='Extent of a smaller focus region of interest \nlon1 lon2 lat1 lat2 in West East South North format.')
     parser.add_argument('--parallel', action='store_true',

--- a/bin/sdown
+++ b/bin/sdown
@@ -20,6 +20,7 @@ Now supports:
                 VNP03MOD,       VJ103MOD,       VJ203MOD
                 VNP02MOD,       VJ102MOD,       VJ202MOD
                 VNP_CLDPROP_L2, VJ1_CLDPROP_L2
+                VNP09,          VJ109
 
     OCO-2 data: coming soon...
 

--- a/bin/sdown
+++ b/bin/sdown
@@ -68,7 +68,7 @@ _description_ = '=' * _width_ + '\n\n' + \
 _prog_        = os.path.basename(sys.argv[0])
 
 # product tags
-# this <_sat_tags_support_> will be updated over time
+# this <_sat_tags_support_> will be updated over time in common.py
 #/----------------------------------------------------------------------------\#
 _today_dt    = datetime.datetime.now(datetime.timezone.utc)
 _today_dt    = _today_dt.replace(tzinfo=None) # so that timedelta does not raise an error
@@ -84,371 +84,7 @@ _noaa21_viirs_start_date = datetime.datetime(2023, 2, 10)
 # Near Real Time (NRT) is available only for the most recent ~ 7 days
 _nrt_oldest_dt = _today_dt - datetime.timedelta(days=7)
 
-_sat_tags_support_ = {
-
-        'MODRGB': {
-                'dataset_tag': 'MODRGB',
-                   'dict_key': 'mod_rgb',
-                'description': 'Terra MODIS True Color (RGB) Imagery',
-                    'website': 'https://worldview.earthdata.nasa.gov',
-                  'satellite': 'Terra',
-                 'instrument': 'MODIS',
-                  'reference': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
-                },
-
-        'MYDRGB': {
-                'dataset_tag': 'MYDRGB',
-                   'dict_key': 'myd_rgb',
-                'description': 'Aqua MODIS True Color (RGB) Imagery',
-                    'website': 'https://worldview.earthdata.nasa.gov',
-                  'satellite': 'Aqua',
-                 'instrument': 'MODIS',
-                  'reference': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
-                },
-
-        'MOD03': {
-                'dataset_tag': '61/MOD03',
-                   'dict_key': 'mod_03',
-                'description': 'Terra MODIS Geolocation Fields Product',
-                    'website': 'http://dx.doi.org/10.5067/MODIS/MOD03.061',
-                  'satellite': 'Terra',
-                 'instrument': 'MODIS',
-                  'reference': 'MODIS Characterization Support Team: MODIS Geolocation Fields Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD03.061 (last access: %s), 2017.' % _date_today_,
-                },
-
-        'MYD03': {
-                'dataset_tag': '61/MYD03',
-                   'dict_key': 'myd_03',
-                'description': 'Aqua MODIS Geolocation Fields Product',
-                    'website': 'http://dx.doi.org/10.5067/MODIS/MYD03.061',
-                  'satellite': 'Aqua',
-                 'instrument': 'MODIS',
-                  'reference': 'MODIS Characterization Support Team: MODIS Geolocation Fields Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD03.061 (last access: %s), 2017.' % _date_today_,
-                },
-
-        'MOD02QKM': {
-                'dataset_tag': '61/MOD02QKM',
-                   'dict_key': 'mod_02',
-                'description': 'Terra MODIS Level 1b (250m) Calibrated Radiances Product',
-                    'website': 'http://dx.doi.org/10.5067/MODIS/MOD02QKM.061',
-                  'satellite': 'Terra',
-                 'instrument': 'MODIS',
-                  'reference': 'MODIS Characterization Support Team: MODIS 250m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD02QKM.061 (last access: %s), 2017.' % _date_today_,
-                },
-
-        'MYD02QKM': {
-                'dataset_tag': '61/MYD02QKM',
-                   'dict_key': 'myd_02',
-                'description': 'Aqua MODIS Level 1b (250m) Calibrated Radiances Product',
-                    'website': 'http://dx.doi.org/10.5067/MODIS/MYD02QKM.061',
-                  'satellite': 'Aqua',
-                 'instrument': 'MODIS',
-                  'reference': 'MODIS Characterization Support Team: MODIS 250m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD02QKM.061 (last access: %s), 2017.' % _date_today_,
-                },
-
-        'MOD02HKM': {
-                'dataset_tag': '61/MOD02HKM',
-                   'dict_key': 'mod_02',
-                'description': 'Terra MODIS Level 1b (500m) Calibrated Radiances Product',
-                    'website': 'http://dx.doi.org/10.5067/MODIS/MOD02HKM.061',
-                  'satellite': 'Terra',
-                 'instrument': 'MODIS',
-                  'reference': 'MODIS Characterization Support Team: MODIS 500m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD02HKM.061 (last access: %s), 2017.' % _date_today_,
-                },
-
-        'MYD02HKM': {
-                'dataset_tag': '61/MYD02HKM',
-                   'dict_key': 'myd_02',
-                'description': 'Aqua MODIS Level 1b (250m) Calibrated Radiances Product',
-                    'website': 'http://dx.doi.org/10.5067/MODIS/MYD02HKM.061',
-                  'satellite': 'Aqua',
-                 'instrument': 'MODIS',
-                  'reference': 'MODIS Characterization Support Team: MODIS 500m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD02HKM.061 (last access: %s), 2017.' % _date_today_,
-                },
-
-        'MOD021KM': {
-                'dataset_tag': '61/MOD021KM',
-                   'dict_key': 'mod_02',
-                'description': 'Terra MODIS Level 1b (1km) Calibrated Radiances Product',
-                    'website': 'http://dx.doi.org/10.5067/MODIS/MOD021KM.061',
-                  'satellite': 'Terra',
-                 'instrument': 'MODIS',
-                  'reference': 'MODIS Characterization Support Team: MODIS 1km Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD021KM.061 (last access: %s), 2017.' % _date_today_,
-                },
-
-        'MYD021KM': {
-                'dataset_tag': '61/MYD021KM',
-                   'dict_key': 'myd_02',
-                'description': 'Aqua MODIS Level 1b (1km) Calibrated Radiances Product',
-                    'website': 'http://dx.doi.org/10.5067/MODIS/MYD021KM.061',
-                  'satellite': 'Aqua',
-                 'instrument': 'MODIS',
-                  'reference': 'MODIS Characterization Support Team: MODIS 1km Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD021KM.061 (last access: %s), 2017.' % _date_today_,
-                },
-
-        'MOD06_L2': {
-                'dataset_tag': '61/MOD06_L2',
-                   'dict_key': 'mod_l2',
-                'description': 'Terra MODIS Atmosphere Level 2 Cloud Product',
-                    'website': 'http://dx.doi.org/10.5067/MODIS/MOD06_L2.061',
-                  'satellite': 'Terra',
-                 'instrument': 'MODIS',
-                  'reference': 'Platnick, S., Ackerman, S. A., King, M. D. , Meyer, K., Menzel, W. P. , Holz, R. E., Baum, B. A., and Yang, P., 2015: MODIS atmosphere L2 cloud product (06_L2), NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD06_L2.061 (last access: %s), 2015.' % _date_today_,
-                },
-
-        'MYD06_L2': {
-                'dataset_tag': '61/MYD06_L2',
-                   'dict_key': 'myd_l2',
-                'description': 'Aqua MODIS Atmosphere Level 2 Cloud Product',
-                    'website': 'http://dx.doi.org/10.5067/MODIS/MYD06_L2.061',
-                  'satellite': 'Aqua',
-                 'instrument': 'MODIS',
-                  'reference': 'Platnick, S., Ackerman, S. A., King, M. D. , Meyer, K., Menzel, W. P. , Holz, R. E., Baum, B. A., and Yang, P., 2015: MODIS atmosphere L2 cloud product (06_L2), NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD06_L2.061 (last access: %s), 2015.' % _date_today_,
-                },
-
-        'MOD35_L2': {
-                'dataset_tag': '61/MOD35_L2',
-                   'dict_key': 'mod_l2',
-                'description': 'Terra MODIS Atmosphere Level 2 Cloud Mask',
-                    'website': 'http://dx.doi.org/10.5067/MODIS/MOD35_L2.061',
-                  'satellite': 'Terra',
-                 'instrument': 'MODIS',
-                  'reference': 'Ackerman, S., P. Menzel, R. Frey, B.Baum, 2017. MODIS Atmosphere L2 Cloud Mask Product. NASA MODIS Adaptive Processing System, Goddard Space Flight Center, [doi:10.5067/MODIS/MOD35_L2.061'
-                },
-
-        'MYD35_L2': {
-                'dataset_tag': '61/MYD35_L2',
-                   'dict_key': 'myd_l2',
-                'description': 'Aqua MODIS Atmosphere Level 2 Cloud Mask',
-                    'website': 'http://dx.doi.org/10.5067/MODIS/MYD35_L2.061',
-                  'satellite': 'Aqua',
-                 'instrument': 'MODIS',
-                  'reference': 'Ackerman, S., P. Menzel, R. Frey, B.Baum, 2017. MODIS Atmosphere L2 Cloud Mask Product. NASA MODIS Adaptive Processing System, Goddard Space Flight Center, [doi:10.5067/MODIS/MYD35_L2.061]'
-                },
-
-        'MCD43A3': {
-                'dataset_tag': '61/MCD43A3',
-                   'dict_key': 'mod_43',
-                'description': 'MODIS BRDF/Albedo Level 3 Surface Product',
-                    'website': 'https://doi.org/10.5067/MODIS/MCD43A3.061',
-                  'satellite': 'Terra & Aqua',
-                 'instrument': 'MODIS',
-                  'reference': 'Schaaf, C., and Wang, Z.: MODIS/Terra+Aqua BRDF/Albedo Daily L3 Global - 500m V061, NASA EOSDIS Land Processes DAAC [data set], https://doi.org/10.5067/MODIS/MCD43A3.061 (last access: %s), 2021.' % _date_today_,
-                },
-
-        'VNP02IMG': {
-                'dataset_tag': '5200/VNP02IMG',
-                   'dict_key': 'vnp_02',
-                'description': 'Suomi-NPP VIIRS Level 1b (375m) Calibrated Radiances Product',
-                    'website': 'https://doi.org/10.5067/VIIRS/VNP02IMG.002',
-                  'satellite': 'SNPP',
-                 'instrument': 'VIIRS',
-                  'reference': 'VCST Team. 2016-09-01. VIIRS/NPP Imagery Resolution 6-Min L1B Swath 375m. Version 1. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VNP02IMG.001',
-                },
-
-        'VJ102IMG': {
-                'dataset_tag': '5201/VJ102IMG',
-                   'dict_key': 'vj1_02',
-                'description': 'JPSS1 (NOAA-20) VIIRS Level 1b (375m) Calibrated Radiances Product',
-                    'website': 'https://doi.org/10.5067/VIIRS/VJ102IMG.021',
-                  'satellite': 'NOAA20',
-                 'instrument': 'VIIRS',
-                  'reference': 'VCST Team. 2019-08-01. VIIRS/JPSS1 Imagery Resolution 6-Min L1B Swath 375m. Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VJ102IMG.002',
-                },
-
-         'VJ202IMG': {
-                'dataset_tag': '5200/VJ202IMG',
-                   'dict_key': 'vj2_02',
-                'description': 'JPSS2 (NOAA-21) VIIRS Level 1b (375m) Calibrated Radiances Product',
-                    'website': 'https://doi.org/10.5067/VIIRS/VJ202IMG.021',
-                  'satellite': 'NOAA21',
-                 'instrument': 'VIIRS',
-                  'reference': 'VCST Team. 2019-08-01. VIIRS/JPSS2 Imagery Resolution 6-Min L1B Swath 375m. Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VJ202IMG.002',
-                },
-
-        'VNP02MOD': {
-                'dataset_tag': '5200/VNP02MOD',
-                   'dict_key': 'vnp_02',
-                'description': 'Suomi-NPP VIIRS Level 1b (750m) Calibrated Radiances Product',
-                    'website': 'https://doi.org/10.5067/VIIRS/VNP02MOD.002',
-                  'satellite': 'SNPP',
-                 'instrument': 'VIIRS',
-                  'reference': 'VCST Team. 2021-07-12. VIIRS/NPP Moderate Resolution Terrain Corrected Geolocation 6-Min L1 Swath 750 m . Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VNP02MOD.002.',
-                },
-
-        'VJ102MOD': {
-                'dataset_tag': '5201/VJ102MOD',
-                   'dict_key': 'vj1_02',
-                'description': 'JPSS1 (NOAA-20) VIIRS Level 1b (750m) Calibrated Radiances Product',
-                    'website': 'https://doi.org/10.5067/VIIRS/VJ102MOD.021',
-                  'satellite': 'NOAA20',
-                 'instrument': 'VIIRS',
-                  'reference': 'VCST Team. 2019-08-01. VIIRS/JPSS1 Moderate Resolution 6-Min L1B Swath 750m. Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VJ102MOD.002',
-                },
-
-        'VJ202MOD': {
-                'dataset_tag': '5200/VJ202MOD',
-                   'dict_key': 'vj2_02',
-                'description': 'JPSS2 (NOAA-21) VIIRS Level 1b (750m) Calibrated Radiances Product',
-                    'website': 'https://doi.org/10.5067/VIIRS/VJ202MOD.021',
-                  'satellite': 'NOAA21',
-                 'instrument': 'VIIRS',
-                  'reference': 'VCST Team. 2019-08-01. VIIRS/JPSS2 Moderate Resolution 6-Min L1B Swath 750m. Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VJ202MOD.002',
-                },
-
-        'VNP03IMG': {
-                'dataset_tag': '5200/VNP03IMG',
-                   'dict_key': 'vnp_03',
-                'description': 'Suomi-NPP VIIRS (375m) Geolocation Fields Product',
-                    'website': 'https://doi.org/10.5067/VIIRS/VNP03IMG.002',
-                  'satellite': 'SNPP',
-                 'instrument': 'VIIRS',
-                  'reference': 'VCST Team. VIIRS/NPP Imagery Resolution Terrain-Corrected Geolocation 6-Min L1 Swath 375m Light. Version 1. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VNP03IMGLL.001',
-                },
-
-        'VJ103IMG': {
-                'dataset_tag': '5201/VJ103IMG',
-                   'dict_key': 'vj1_03',
-                'description': 'JPSS1 (NOAA-20) VIIRS (375m) Geolocation Fields Product',
-                    'website': 'https://doi.org/10.5067/VIIRS/VJ103IMG.021',
-                  'satellite': 'NOAA20',
-                 'instrument': 'VIIRS',
-                  'reference': 'VCST Team. VIIRS/JPSS1 Imagery Resolution Terrain-Corrected Geolocation 6-Min L1 Swath 375m Light. Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VJ103IMG.021',
-                },
-
-        'VJ203IMG': {
-                'dataset_tag': '5200/VJ203IMG',
-                   'dict_key': 'vj2_03',
-                'description': 'JPSS2 (NOAA-21) VIIRS (375m) Geolocation Fields Product',
-                    'website': 'https://doi.org/10.5067/VIIRS/VJ203IMG.021',
-                  'satellite': 'NOAA21',
-                 'instrument': 'VIIRS',
-                  'reference': 'VCST Team. VIIRS/JPSS2 Imagery Resolution Terrain-Corrected Geolocation 6-Min L1 Swath 375m Light. Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VJ203IMG.021',
-                },
-
-        'VNP03MOD': {
-                'dataset_tag': '5200/VNP03MOD',
-                   'dict_key': 'vnp_03',
-                'description': 'Suomi-NPP VIIRS (750m) Geolocation Fields Product',
-                    'website': 'https://doi.org/10.5067/VIIRS/VNP03MOD.002',
-                  'satellite': 'SNPP',
-                 'instrument': 'VIIRS',
-                  'reference': 'VCST Team. 2021-07-12. VIIRS/NPP Moderate Resolution Terrain-Corrected Geolocation L1 6-Min Swath 750 m. Version 2. LAADS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VNP03MOD.002',
-                },
-
-        'VJ103MOD': {
-                'dataset_tag': '5201/VJ103MOD',
-                   'dict_key': 'vj1_03',
-                'description': 'JPSS1 (NOAA-20) VIIRS (750m) Geolocation Fields Product',
-                    'website': 'https://doi.org/10.5067/VIIRS/VJ103MOD.021',
-                  'satellite': 'NOAA20',
-                 'instrument': 'VIIRS',
-                  'reference': 'VCST Team. 2019-08-01. VIIRS/JPSS1 Moderate Resolution Terrain Corrected Geolocation 6-Min L1 Swath 750m. Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VJ103MOD.002',
-                },
-
-         'VJ203MOD': {
-                'dataset_tag': '5200/VJ203MOD',
-                   'dict_key': 'vj2_03',
-                'description': 'JPSS2 (NOAA-21) VIIRS (750m) Geolocation Fields Product',
-                    'website': 'https://doi.org/10.5067/VIIRS/VJ203MOD.021',
-                  'satellite': 'NOAA21',
-                 'instrument': 'VIIRS',
-                  'reference': 'VCST Team. 2019-08-01. VIIRS/JPSS1 Moderate Resolution Terrain Corrected Geolocation 6-Min L1 Swath 750m. Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VJ203MOD.002',
-                },
-
-        'VNPRGB': {
-                'dataset_tag': '5200/VNPRGB',
-                   'dict_key': 'vnp_rgb',
-                'description': 'Suomi-NPP VIIRS True Color (RGB) Imagery',
-                    'website': 'https://worldview.earthdata.nasa.gov',
-                  'satellite': 'SNPP',
-                 'instrument': 'VIIRS',
-                  'reference': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
-                },
-
-        'VJ1RGB': {
-                'dataset_tag': '5201/VJ1RGB',
-                   'dict_key': 'vj1_rgb',
-                'description': 'JPSS1 (NOAA-20) VIIRS True Color (RGB) Imagery',
-                    'website': 'https://worldview.earthdata.nasa.gov',
-                  'satellite': 'NOAA20',
-                 'instrument': 'VIIRS',
-                  'reference': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
-                },
-
-        'VJ2RGB': {
-                'dataset_tag': '5200/VJ2RGB',
-                   'dict_key': 'vj2_rgb',
-                'description': 'JPSS2 (NOAA-21) VIIRS True Color (RGB) Imagery',
-                    'website': 'https://worldview.earthdata.nasa.gov',
-                  'satellite': 'NOAA21',
-                 'instrument': 'VIIRS',
-                  'reference': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
-                },
-
-        'VNP_CLDPROP_L2': {
-                'dataset_tag': '5111/CLDPROP_L2_VIIRS_SNPP',
-                   'dict_key': 'vnp_l2',
-                'description': 'Suomi-NPP VIIRS Cloud Properties Product',
-                    'website': 'https://doi.org/10.5067/VIIRS/CLDPROP_L2_VIIRS_SNPP.011',
-                  'satellite': 'SNPP',
-                 'instrument': 'VIIRS',
-                  'reference': 'NASA VIIRS Atmosphere SIPS. 2019-11-15. VIIRS/SNPP Cloud Properties 6-min L2 Swath 750m. Version 1.1. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS).',
-                },
-
-        'VJ1_CLDPROP_L2': {
-                'dataset_tag': '5111/CLDPROP_L2_VIIRS_NOAA20',
-                   'dict_key': 'vj1_l2',
-                'description': 'JPSS1 (NOAA-20) VIIRS Cloud Properties Product',
-                    'website': 'https://ladsweb.modaps.eosdis.nasa.gov/missions-and-measurements/products/CLDPROP_L2_VIIRS_NOAA20',
-                  'satellite': 'NOAA20',
-                 'instrument': 'VIIRS',
-                  'reference': 'NASA VIIRS Atmosphere SIPS. 2019-11-15. VIIRS/JPSS1 Cloud Properties 6-min L2 Swath 750m. Version 1.1. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS).',
-                },
-
-        ## commenting this out as cloud products for NOAA-21 are not available yet
-        # 'VJ2_CLDPROP_L2': {
-        #         'dataset_tag': '5111/CLDPROP_L2_VIIRS_NOAA21',
-        #            'dict_key': 'vj2_l2',
-        #         'description': 'JPSS2 (NOAA-21) VIIRS Cloud Properties Product',
-        #             'website': 'https://ladsweb.modaps.eosdis.nasa.gov/missions-and-measurements/products/CLDPROP_L2_VIIRS_NOAA21',
-        #           'satellite': 'NOAA21',
-        #          'instrument': 'VIIRS',
-        #           'reference': 'NASA VIIRS Atmosphere SIPS. 2019-11-15. VIIRS/JPSS2 Cloud Properties 6-min L2 Swath 750m. Version 1.1. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS).',
-        #         },
-
-        'oco2_L1bScND': {
-                'dataset_tag': 'oco2_L1bScND',
-                   'dict_key': 'oco_l1b',
-                'description': 'OCO-2 L1B Calibrated Radiances Product',
-                    'website': 'https://doi.org/10.5067/6O3GEUK7U2JG',
-                  'satellite': 'OCO-2',
-                 'instrument': 'OCO-2',
-                  'reference': 'OCO-2 Science Team/Gunson, M., and Eldering, A.: OCO-2 Level 1B calibrated, geolocated science spectra, Retrospective Processing V10r, Goddard Earth Sciences Data and Information Services Center (GES DISC) [data set], Greenbelt, MD, USA, https://doi.org/10.5067/6O3GEUK7U2JG (last access: %s), 2019.' % _date_today_,
-                },
-
-        'oco2_L2MetND': {
-                'dataset_tag': 'oco2_L2MetND',
-                   'dict_key': 'oco_met_l2',
-                'description': 'OCO-2 L2 Meteorological Parameters Product',
-                    'website': 'https://doi.org/10.5067/OJZZW0LIGSDH',
-                  'satellite': 'OCO-2',
-                 'instrument': 'OCO-2',
-                  'reference': 'OCO-2 Science Team/Gunson, M., and Eldering, A.: OCO-2 Level 2 meteorological parameters interpolated from global assimilation model for each sounding, Retrospective Processing V10r, Goddard Earth Sciences Data and Information Services Center (GES DISC) [data set], Greenbelt, MD, USA, https://doi.org/10.5067/OJZZW0LIGSDH (last access: %s), 2019.' % _date_today_,
-                },
-
-        'oco2_L2StdND': {
-                'dataset_tag': 'oco2_L2StdND',
-                   'dict_key': 'oco_ret_l2',
-                'description': 'OCO-2 L2 XCO2 Retrieval Product',
-                    'website': 'https://doi.org/10.5067/6SBROTA57TFH',
-                  'satellite': 'OCO-2',
-                 'instrument': 'OCO-2',
-                  'reference': 'OCO-2 Science Team/Gunson, M., and Eldering, A.: OCO-2 Level 2 geolocated XCO2 retrievals results, physical model, Retrospective Processing V10r, Goddard Earth Sciences Data and Information Services Center (GES DISC) [data set], Greenbelt, MD, USA, https://doi.org/10.5067/6SBROTA57TFH (last access: %s), 2020.' % _date_today_,
-                },
-
-        }
-#\----------------------------------------------------------------------------/#
+########################################################################################
 
 def create_args_parallel(date_list,
                          start_dt_hhmm,
@@ -507,7 +143,7 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
     ########################################################################################################
 
     if products is None:
-        msg = 'Error [sdown]: Please specify a product to download. \nWe currently support the following:\n{}'.format('\n'.join(_sat_tags_support_.keys()))
+        msg = 'Error [sdown]: Please specify a product to download. \nWe currently support the following:\n{}'.format('\n'.join(er3t.common._sat_tags_support_.keys()))
         satlogger.error(msg)
         sys.exit()
 
@@ -895,7 +531,7 @@ def run(date, start_dt_hhmm, end_dt_hhmm, extent, fdir_out, nrt, iou, focus_exte
                     fnames[product_info['dict_key']] += p_fnames
 
         else:
-            msg = 'Error [sdown]: Cannot recognize satellite product from the given tag <%s>, abort...\nCurrently, only the following satellite products are supported by <sdown>:\n%s' % (product, '\n'.join(_sat_tags_support_.keys()))
+            msg = 'Error [sdown]: Cannot recognize satellite product from the given tag <%s>, abort...\nCurrently, only the following satellite products are supported by <sdown>:\n%s' % (product, '\n'.join(er3t.common._sat_tags_support_.keys()))
             satlogger.error(msg)
             raise OSError()
 
@@ -918,8 +554,8 @@ def get_sat_info_from_product_tag(tag_):
     # make all variable names (keys) upper case
     #/----------------------------------------------------------------------------\#
     tags_support = {}
-    for key in _sat_tags_support_.keys():
-        tags_support[key.upper()] = _sat_tags_support_[key]
+    for key in er3t.common._sat_tags_support_.keys():
+        tags_support[key.upper()] = er3t.common._sat_tags_support_[key]
     #\----------------------------------------------------------------------------/#
 
     # return satellite product information
@@ -928,7 +564,7 @@ def get_sat_info_from_product_tag(tag_):
     if (tag in tags_support.keys()):
         return tags_support[tag]
     else:
-        msg = '\nError [sdown]: Cannot recognize satellite product from the given tag <%s>, abort...\nCurrently, only the following satellite products are supported by <sdown>:\n%s' % (tag_, '\n'.join(_sat_tags_support_.keys()))
+        msg = '\nError [sdown]: Cannot recognize satellite product from the given tag <%s>, abort...\nCurrently, only the following satellite products are supported by <sdown>:\n%s' % (tag_, '\n'.join(er3t.common._sat_tags_support_.keys()))
         satlogger.error(msg)
         raise OSError()
     #\----------------------------------------------------------------------------/#

--- a/bin/sdown
+++ b/bin/sdown
@@ -359,7 +359,7 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
             # need to create dirs and write metadata before
             fdir_out_dt_list = []
             for date_x in date_list: # download products date by date
-                fdir_out_dt = os.path.join(fdir_out, date_x.strftime('%Y_%m_%d')) # save files in dirs with dates specified
+                fdir_out_dt = os.path.join(fdir_out, date_x.strftime('%Y-%m-%d')) # save files in dirs with dates specified
                 if not os.path.exists(fdir_out_dt):
                     os.makedirs(fdir_out_dt)
 
@@ -379,7 +379,7 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
 
         else: # run as usual
             for date_x in date_list: # download products date by date
-                fdir_out_dt = os.path.join(fdir_out, date_x.strftime('%Y_%m_%d')) # save files in dirs with dates specified
+                fdir_out_dt = os.path.join(fdir_out, date_x.strftime('%Y-%m-%d')) # save files in dirs with dates specified
                 if not os.path.exists(fdir_out_dt):
                     os.makedirs(fdir_out_dt)
 

--- a/bin/sdown
+++ b/bin/sdown
@@ -643,6 +643,7 @@ if __name__ == '__main__':
         products   = ['MODRGB', 'VNP02IMG']
         nrt        = False
         iou        = 0
+        geojson    = None
         focus_extent = None
         parallel   = False
         verbose    = 1
@@ -659,6 +660,7 @@ if __name__ == '__main__':
                                   fdir_out=fdir,
                                   nrt=nrt,
                                   iou=iou,
+                                  geojson_fpath=geojson,
                                   focus_extent=focus_extent,
                                   products=products,
                                   parallel=parallel,
@@ -677,6 +679,7 @@ if __name__ == '__main__':
                                   fdir_out=args.fdir,
                                   nrt=args.nrt,
                                   iou=args.iou,
+                                  geojson_fpath=args.geojson,
                                   focus_extent=args.focus_extent,
                                   products=args.products,
                                   parallel=args.parallel,

--- a/bin/sdown
+++ b/bin/sdown
@@ -395,7 +395,8 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
                 run(date=date_x,
                     start_dt_hhmm=start_dt,
                     end_dt_hhmm=end_dt,
-                    extent=extent,
+                    lons=llons,
+                    lats=llats,
                     fdir_out=fdir_out_dt,
                     nrt=nrt,
                     iou=iou,
@@ -405,16 +406,16 @@ def satellite_download(date, start_date, end_date, extent, lons, lats, fdir_out,
 
 
 
-def run(date, start_dt_hhmm, end_dt_hhmm, extent, fdir_out, nrt, iou, focus_extent, products, verbose):
+def run(date, start_dt_hhmm, end_dt_hhmm, lons, lats, fdir_out, nrt, iou, focus_extent, products, verbose):
 
     if focus_extent is not None:
-        lon0 = np.linspace(focus_extent[0], focus_extent[1], 100)
-        lat0 = np.linspace(focus_extent[2], focus_extent[3], 100)
-    else:
-        lon0 = np.linspace(extent[0], extent[1], 100)
-        lat0 = np.linspace(extent[2], extent[3], 100)
+        lons = np.linspace(focus_extent[0], focus_extent[1], 200)
+        lats = np.linspace(focus_extent[2], focus_extent[3], 200)
+    # else: # disabled since we are now pre-calculating lons and lats
+    #     lons = np.linspace(extent[0], extent[1], 100)
+    #     lats = np.linspace(extent[2], extent[3], 100)
 
-    lon, lat = np.meshgrid(lon0, lat0, indexing='ij')
+    lon, lat = np.meshgrid(lons, lats, indexing='ij')
 
     references = []
     fnames = {}

--- a/er3t/common.py
+++ b/er3t/common.py
@@ -412,6 +412,26 @@ _sat_tags_support_ = {
         #           'reference': 'NASA VIIRS Atmosphere SIPS. 2019-11-15. VIIRS/JPSS2 Cloud Properties 6-min L2 Swath 750m. Version 1.1. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS).',
         #         },
 
+        'VNP09': {
+                'dataset_tag': '5200/VNP09',
+                   'dict_key': 'vnp_09',
+                'description': 'VIIRS/NPP Atmospherically Corrected Surface Reflectance 6-Min L2 Swath IP 375m, 750m',
+                    'website': 'n/a',
+                  'satellite': 'SNPP',
+                 'instrument': 'VIIRS',
+                  'reference': 'Roger, J. C., Vermote, E. F., Devadiga, S., & Ray, J. P. (2016). Suomi-NPP VIIRS Surface Reflectance User’s Guide. V1 Re-processing (NASA Land SIPS).'
+                },
+
+        'VJ109': {
+                'dataset_tag': '5200/VJ109',
+                   'dict_key': 'vj1_09',
+                'description': 'VIIRS/JPSS1 Atmospherically Corrected Surface Reflectance 6-Min L2 Swath IP 375m, 750m',
+                    'website': 'n/a',
+                  'satellite': 'NOAA20',
+                 'instrument': 'VIIRS',
+                  'reference': 'Roger, J. C., Vermote, E. F., Devadiga, S., & Ray, J. P. (2016). Suomi-NPP VIIRS Surface Reflectance User’s Guide. V1 Re-processing (NASA Land SIPS).'
+                },
+
         'oco2_L1bScND': {
                 'dataset_tag': 'oco2_L1bScND',
                    'dict_key': 'oco_l1b',

--- a/er3t/common.py
+++ b/er3t/common.py
@@ -201,6 +201,26 @@ _sat_tags_support_ = {
                   'reference': 'Ackerman, S., P. Menzel, R. Frey, B.Baum, 2017. MODIS Atmosphere L2 Cloud Mask Product. NASA MODIS Adaptive Processing System, Goddard Space Flight Center, [doi:10.5067/MODIS/MYD35_L2.061]'
                 },
 
+        'MOD09': {
+                'dataset_tag': '61/MOD09',
+                   'dict_key': 'mod_09',
+                'description': 'Terra MODIS Atmosphere Level 2 Atmospherically Corrected Surface Reflectance',
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MOD09.061',
+                  'satellite': 'Terra',
+                 'instrument': 'MODIS',
+                  'reference': 'Eric Vermote - NASA GSFC and MODAPS SIPS - NASA. (2015). MOD09 MODIS/Terra L2 Surface Reflectance, 5-Min Swath 250m, 500m, and 1km. NASA LP DAAC. http://doi.org/10.5067/MODIS/MOD09.061'
+                },
+
+        'MYD09': {
+                'dataset_tag': '61/MYD09',
+                   'dict_key': 'myd_09',
+                'description': 'Aqua MODIS Atmosphere Level 2 Atmospherically Corrected Surface Reflectance',
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MYD09.061',
+                  'satellite': 'Aqua',
+                 'instrument': 'MODIS',
+                  'reference': 'Eric Vermote - NASA GSFC and MODAPS SIPS - NASA. (2015). MYD09 MODIS/Aqua L2 Surface Reflectance, 5-Min Swath 250m, 500m, and 1km. NASA LP DAAC. http://doi.org/10.5067/MODIS/MYD09.061'
+                },
+
         'MCD43A3': {
                 'dataset_tag': '61/MCD43A3',
                    'dict_key': 'mod_43',

--- a/er3t/common.py
+++ b/er3t/common.py
@@ -227,7 +227,7 @@ _sat_tags_support_ = {
         'MYD_CLDMSK_L2': {
                 'dataset_tag': '5110/CLDMSK_L2_MODIS_Aqua',
                    'dict_key': 'myd_cldmsk_l2',
-                'description': 'MODIS/Aqua Cloud Mask 5-Min Swath 1 km',
+                'description': 'Aqua MODIS Continuity Cloud Mask (MVCM) 5-Min Swath 1 km',
                         'doi': '10.5067/MODIS/CLDMSK_L2_MODIS_Aqua.001',
                     'website': 'https://ladsweb.modaps.eosdis.nasa.gov/missions-and-measurements/products/CLDMSK_L2_MODIS_Aqua',
                   'satellite': 'Aqua',
@@ -238,7 +238,7 @@ _sat_tags_support_ = {
         'AQUA_CLDMSK_L2': {
                 'dataset_tag': '5110/CLDMSK_L2_MODIS_Aqua',
                    'dict_key': 'myd_cldmsk_l2',
-                'description': 'MODIS/Aqua Cloud Mask 5-Min Swath 1 km',
+                'description': 'Aqua MODIS Continuity Cloud Mask (MVCM) 5-Min Swath 1 km',
                         'doi': '10.5067/MODIS/CLDMSK_L2_MODIS_Aqua.001',
                     'website': 'https://ladsweb.modaps.eosdis.nasa.gov/missions-and-measurements/products/CLDMSK_L2_MODIS_Aqua',
                   'satellite': 'Aqua',
@@ -460,7 +460,7 @@ _sat_tags_support_ = {
         'VNP_CLDMSK_L2': {
                 'dataset_tag': '5110/CLDMSK_L2_VIIRS_SNPP',
                    'dict_key': 'vnp_cldmsk_l2',
-                'description': 'VIIRS/SNPP Cloud Mask 6-Min Swath 750 m',
+                'description': 'SNPP VIIRS Continuity Cloud Mask (MVCM) 6-Min Swath 750 m',
                         'doi': '10.5067/VIIRS/CLDMSK_L2_VIIRS_SNPP.001',
                     'website': 'https://ladsweb.modaps.eosdis.nasa.gov/missions-and-measurements/products/CLDMSK_L2_VIIRS_SNPP',
                   'satellite': 'SNPP',
@@ -471,7 +471,7 @@ _sat_tags_support_ = {
          'VJ1_CLDMSK_L2': {
                 'dataset_tag': '5110/CLDMSK_L2_VIIRS_NOAA20',
                    'dict_key': 'vj1_cldmsk_l2',
-                'description': 'VIIRS/NOAA20 (JPSS1) Cloud Mask 6-Min Swath 750 m',
+                'description': 'NOAA20 (JPSS1) VIIRS Continuity Cloud Mask (MVCM) 6-Min Swath 750 m',
                         'doi': '10.5067/VIIRS/CLDMSK_L2_VIIRS_NOAA20.001',
                     'website': 'https://ladsweb.modaps.eosdis.nasa.gov/missions-and-measurements/products/CLDMSK_L2_VIIRS_NOAA20',
                   'satellite': 'NOAA20',
@@ -482,7 +482,7 @@ _sat_tags_support_ = {
           'VJ2_CLDMSK_L2': {
                 'dataset_tag': '5110/CLDMSK_L2_VIIRS_NOAA21',
                    'dict_key': 'vj2_cldmsk_l2',
-                'description': 'VIIRS/NOAA21 (JPSS2) Cloud Mask 6-Min Swath 750 m',
+                'description': 'NOAA21 (JPSS2) VIIRS Continuity Cloud Mask (MVCM) 6-Min Swath 750 m',
                         'doi': '10.5067/VIIRS/CLDMSK_L2_VIIRS_NOAA21.001',
                     'website': 'https://ladsweb.modaps.eosdis.nasa.gov/missions-and-measurements/products/CLDMSK_L2_VIIRS_NOAA21',
                   'satellite': 'NOAA21',

--- a/er3t/common.py
+++ b/er3t/common.py
@@ -415,7 +415,7 @@ _sat_tags_support_ = {
         'VNP09': {
                 'dataset_tag': '5200/VNP09',
                    'dict_key': 'vnp_09',
-                'description': 'VIIRS/NPP Atmospherically Corrected Surface Reflectance 6-Min L2 Swath IP 375m, 750m',
+                'description': 'Suomi-NPP VIIRS Atmospherically Corrected Surface Reflectance Product',
                     'website': 'n/a',
                   'satellite': 'SNPP',
                  'instrument': 'VIIRS',
@@ -425,7 +425,7 @@ _sat_tags_support_ = {
         'VJ109': {
                 'dataset_tag': '5200/VJ109',
                    'dict_key': 'vj1_09',
-                'description': 'VIIRS/JPSS1 Atmospherically Corrected Surface Reflectance 6-Min L2 Swath IP 375m, 750m',
+                'description': 'JPSS1 (NOAA-20) Atmospherically Corrected Surface Reflectance Product',
                     'website': 'n/a',
                   'satellite': 'NOAA20',
                  'instrument': 'VIIRS',

--- a/er3t/common.py
+++ b/er3t/common.py
@@ -53,3 +53,374 @@ params = {
 references = [
 'EaR³T (Chen et al., 2023):\n- Chen, H., Schmidt, K. S., Massie, S. T., Nataraja, V., Norgren, M. S., Gristey, J. J., Feingold, G., Holz, R. E., and Iwabuchi, H.: The Education and Research 3D Radiative Transfer Toolbox (EaR³T) - Towards the Mitigation of 3D Bias in Airborne and Spaceborne Passive Imagery Cloud Retrievals, Atmos. Meas. Tech., 16, 1971–2000, https://doi.org/10.5194/amt-16-1971-2023, 2023.'
         ]
+
+_today_dt    = datetime.datetime.now(datetime.timezone.utc)
+_today_dt    = _today_dt.replace(tzinfo=None) # so that timedelta does not raise an error
+_date_today_ = _today_dt.strftime('%d %B, %Y')
+
+# sdown references
+_sat_tags_support_ = {
+
+        'MODRGB': {
+                'dataset_tag': 'MODRGB',
+                   'dict_key': 'mod_rgb',
+                'description': 'Terra MODIS True Color (RGB) Imagery',
+                    'website': 'https://worldview.earthdata.nasa.gov',
+                  'satellite': 'Terra',
+                 'instrument': 'MODIS',
+                  'reference': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
+                },
+
+        'MYDRGB': {
+                'dataset_tag': 'MYDRGB',
+                   'dict_key': 'myd_rgb',
+                'description': 'Aqua MODIS True Color (RGB) Imagery',
+                    'website': 'https://worldview.earthdata.nasa.gov',
+                  'satellite': 'Aqua',
+                 'instrument': 'MODIS',
+                  'reference': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
+                },
+
+        'MOD03': {
+                'dataset_tag': '61/MOD03',
+                   'dict_key': 'mod_03',
+                'description': 'Terra MODIS Geolocation Fields Product',
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MOD03.061',
+                  'satellite': 'Terra',
+                 'instrument': 'MODIS',
+                  'reference': 'MODIS Characterization Support Team: MODIS Geolocation Fields Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD03.061 (last access: %s), 2017.' % _date_today_,
+                },
+
+        'MYD03': {
+                'dataset_tag': '61/MYD03',
+                   'dict_key': 'myd_03',
+                'description': 'Aqua MODIS Geolocation Fields Product',
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MYD03.061',
+                  'satellite': 'Aqua',
+                 'instrument': 'MODIS',
+                  'reference': 'MODIS Characterization Support Team: MODIS Geolocation Fields Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD03.061 (last access: %s), 2017.' % _date_today_,
+                },
+
+        'MOD02QKM': {
+                'dataset_tag': '61/MOD02QKM',
+                   'dict_key': 'mod_02',
+                'description': 'Terra MODIS Level 1b (250m) Calibrated Radiances Product',
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MOD02QKM.061',
+                  'satellite': 'Terra',
+                 'instrument': 'MODIS',
+                  'reference': 'MODIS Characterization Support Team: MODIS 250m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD02QKM.061 (last access: %s), 2017.' % _date_today_,
+                },
+
+        'MYD02QKM': {
+                'dataset_tag': '61/MYD02QKM',
+                   'dict_key': 'myd_02',
+                'description': 'Aqua MODIS Level 1b (250m) Calibrated Radiances Product',
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MYD02QKM.061',
+                  'satellite': 'Aqua',
+                 'instrument': 'MODIS',
+                  'reference': 'MODIS Characterization Support Team: MODIS 250m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD02QKM.061 (last access: %s), 2017.' % _date_today_,
+                },
+
+        'MOD02HKM': {
+                'dataset_tag': '61/MOD02HKM',
+                   'dict_key': 'mod_02',
+                'description': 'Terra MODIS Level 1b (500m) Calibrated Radiances Product',
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MOD02HKM.061',
+                  'satellite': 'Terra',
+                 'instrument': 'MODIS',
+                  'reference': 'MODIS Characterization Support Team: MODIS 500m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD02HKM.061 (last access: %s), 2017.' % _date_today_,
+                },
+
+        'MYD02HKM': {
+                'dataset_tag': '61/MYD02HKM',
+                   'dict_key': 'myd_02',
+                'description': 'Aqua MODIS Level 1b (250m) Calibrated Radiances Product',
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MYD02HKM.061',
+                  'satellite': 'Aqua',
+                 'instrument': 'MODIS',
+                  'reference': 'MODIS Characterization Support Team: MODIS 500m Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD02HKM.061 (last access: %s), 2017.' % _date_today_,
+                },
+
+        'MOD021KM': {
+                'dataset_tag': '61/MOD021KM',
+                   'dict_key': 'mod_02',
+                'description': 'Terra MODIS Level 1b (1km) Calibrated Radiances Product',
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MOD021KM.061',
+                  'satellite': 'Terra',
+                 'instrument': 'MODIS',
+                  'reference': 'MODIS Characterization Support Team: MODIS 1km Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD021KM.061 (last access: %s), 2017.' % _date_today_,
+                },
+
+        'MYD021KM': {
+                'dataset_tag': '61/MYD021KM',
+                   'dict_key': 'myd_02',
+                'description': 'Aqua MODIS Level 1b (1km) Calibrated Radiances Product',
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MYD021KM.061',
+                  'satellite': 'Aqua',
+                 'instrument': 'MODIS',
+                  'reference': 'MODIS Characterization Support Team: MODIS 1km Calibrated Radiances Product, NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MYD021KM.061 (last access: %s), 2017.' % _date_today_,
+                },
+
+        'MOD06_L2': {
+                'dataset_tag': '61/MOD06_L2',
+                   'dict_key': 'mod_l2',
+                'description': 'Terra MODIS Atmosphere Level 2 Cloud Product',
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MOD06_L2.061',
+                  'satellite': 'Terra',
+                 'instrument': 'MODIS',
+                  'reference': 'Platnick, S., Ackerman, S. A., King, M. D. , Meyer, K., Menzel, W. P. , Holz, R. E., Baum, B. A., and Yang, P., 2015: MODIS atmosphere L2 cloud product (06_L2), NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD06_L2.061 (last access: %s), 2015.' % _date_today_,
+                },
+
+        'MYD06_L2': {
+                'dataset_tag': '61/MYD06_L2',
+                   'dict_key': 'myd_l2',
+                'description': 'Aqua MODIS Atmosphere Level 2 Cloud Product',
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MYD06_L2.061',
+                  'satellite': 'Aqua',
+                 'instrument': 'MODIS',
+                  'reference': 'Platnick, S., Ackerman, S. A., King, M. D. , Meyer, K., Menzel, W. P. , Holz, R. E., Baum, B. A., and Yang, P., 2015: MODIS atmosphere L2 cloud product (06_L2), NASA MODIS Adaptive Processing System [data set], Goddard Space Flight Center, USA, http://dx.doi.org/10.5067/MODIS/MOD06_L2.061 (last access: %s), 2015.' % _date_today_,
+                },
+
+        'MOD35_L2': {
+                'dataset_tag': '61/MOD35_L2',
+                   'dict_key': 'mod_l2',
+                'description': 'Terra MODIS Atmosphere Level 2 Cloud Mask',
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MOD35_L2.061',
+                  'satellite': 'Terra',
+                 'instrument': 'MODIS',
+                  'reference': 'Ackerman, S., P. Menzel, R. Frey, B.Baum, 2017. MODIS Atmosphere L2 Cloud Mask Product. NASA MODIS Adaptive Processing System, Goddard Space Flight Center, [doi:10.5067/MODIS/MOD35_L2.061'
+                },
+
+        'MYD35_L2': {
+                'dataset_tag': '61/MYD35_L2',
+                   'dict_key': 'myd_l2',
+                'description': 'Aqua MODIS Atmosphere Level 2 Cloud Mask',
+                    'website': 'http://dx.doi.org/10.5067/MODIS/MYD35_L2.061',
+                  'satellite': 'Aqua',
+                 'instrument': 'MODIS',
+                  'reference': 'Ackerman, S., P. Menzel, R. Frey, B.Baum, 2017. MODIS Atmosphere L2 Cloud Mask Product. NASA MODIS Adaptive Processing System, Goddard Space Flight Center, [doi:10.5067/MODIS/MYD35_L2.061]'
+                },
+
+        'MCD43A3': {
+                'dataset_tag': '61/MCD43A3',
+                   'dict_key': 'mod_43',
+                'description': 'MODIS BRDF/Albedo Level 3 Surface Product',
+                    'website': 'https://doi.org/10.5067/MODIS/MCD43A3.061',
+                  'satellite': 'Terra & Aqua',
+                 'instrument': 'MODIS',
+                  'reference': 'Schaaf, C., and Wang, Z.: MODIS/Terra+Aqua BRDF/Albedo Daily L3 Global - 500m V061, NASA EOSDIS Land Processes DAAC [data set], https://doi.org/10.5067/MODIS/MCD43A3.061 (last access: %s), 2021.' % _date_today_,
+                },
+
+        'VNP02IMG': {
+                'dataset_tag': '5200/VNP02IMG',
+                   'dict_key': 'vnp_02',
+                'description': 'Suomi-NPP VIIRS Level 1b (375m) Calibrated Radiances Product',
+                    'website': 'https://doi.org/10.5067/VIIRS/VNP02IMG.002',
+                  'satellite': 'SNPP',
+                 'instrument': 'VIIRS',
+                  'reference': 'VCST Team. 2016-09-01. VIIRS/NPP Imagery Resolution 6-Min L1B Swath 375m. Version 1. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VNP02IMG.001',
+                },
+
+        'VJ102IMG': {
+                'dataset_tag': '5201/VJ102IMG',
+                   'dict_key': 'vj1_02',
+                'description': 'JPSS1 (NOAA-20) VIIRS Level 1b (375m) Calibrated Radiances Product',
+                    'website': 'https://doi.org/10.5067/VIIRS/VJ102IMG.021',
+                  'satellite': 'NOAA20',
+                 'instrument': 'VIIRS',
+                  'reference': 'VCST Team. 2019-08-01. VIIRS/JPSS1 Imagery Resolution 6-Min L1B Swath 375m. Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VJ102IMG.002',
+                },
+
+         'VJ202IMG': {
+                'dataset_tag': '5200/VJ202IMG',
+                   'dict_key': 'vj2_02',
+                'description': 'JPSS2 (NOAA-21) VIIRS Level 1b (375m) Calibrated Radiances Product',
+                    'website': 'https://doi.org/10.5067/VIIRS/VJ202IMG.021',
+                  'satellite': 'NOAA21',
+                 'instrument': 'VIIRS',
+                  'reference': 'VCST Team. 2019-08-01. VIIRS/JPSS2 Imagery Resolution 6-Min L1B Swath 375m. Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VJ202IMG.002',
+                },
+
+        'VNP02MOD': {
+                'dataset_tag': '5200/VNP02MOD',
+                   'dict_key': 'vnp_02',
+                'description': 'Suomi-NPP VIIRS Level 1b (750m) Calibrated Radiances Product',
+                    'website': 'https://doi.org/10.5067/VIIRS/VNP02MOD.002',
+                  'satellite': 'SNPP',
+                 'instrument': 'VIIRS',
+                  'reference': 'VCST Team. 2021-07-12. VIIRS/NPP Moderate Resolution Terrain Corrected Geolocation 6-Min L1 Swath 750 m . Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VNP02MOD.002.',
+                },
+
+        'VJ102MOD': {
+                'dataset_tag': '5201/VJ102MOD',
+                   'dict_key': 'vj1_02',
+                'description': 'JPSS1 (NOAA-20) VIIRS Level 1b (750m) Calibrated Radiances Product',
+                    'website': 'https://doi.org/10.5067/VIIRS/VJ102MOD.021',
+                  'satellite': 'NOAA20',
+                 'instrument': 'VIIRS',
+                  'reference': 'VCST Team. 2019-08-01. VIIRS/JPSS1 Moderate Resolution 6-Min L1B Swath 750m. Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VJ102MOD.002',
+                },
+
+        'VJ202MOD': {
+                'dataset_tag': '5200/VJ202MOD',
+                   'dict_key': 'vj2_02',
+                'description': 'JPSS2 (NOAA-21) VIIRS Level 1b (750m) Calibrated Radiances Product',
+                    'website': 'https://doi.org/10.5067/VIIRS/VJ202MOD.021',
+                  'satellite': 'NOAA21',
+                 'instrument': 'VIIRS',
+                  'reference': 'VCST Team. 2019-08-01. VIIRS/JPSS2 Moderate Resolution 6-Min L1B Swath 750m. Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VJ202MOD.002',
+                },
+
+        'VNP03IMG': {
+                'dataset_tag': '5200/VNP03IMG',
+                   'dict_key': 'vnp_03',
+                'description': 'Suomi-NPP VIIRS (375m) Geolocation Fields Product',
+                    'website': 'https://doi.org/10.5067/VIIRS/VNP03IMG.002',
+                  'satellite': 'SNPP',
+                 'instrument': 'VIIRS',
+                  'reference': 'VCST Team. VIIRS/NPP Imagery Resolution Terrain-Corrected Geolocation 6-Min L1 Swath 375m Light. Version 1. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VNP03IMGLL.001',
+                },
+
+        'VJ103IMG': {
+                'dataset_tag': '5201/VJ103IMG',
+                   'dict_key': 'vj1_03',
+                'description': 'JPSS1 (NOAA-20) VIIRS (375m) Geolocation Fields Product',
+                    'website': 'https://doi.org/10.5067/VIIRS/VJ103IMG.021',
+                  'satellite': 'NOAA20',
+                 'instrument': 'VIIRS',
+                  'reference': 'VCST Team. VIIRS/JPSS1 Imagery Resolution Terrain-Corrected Geolocation 6-Min L1 Swath 375m Light. Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VJ103IMG.021',
+                },
+
+        'VJ203IMG': {
+                'dataset_tag': '5200/VJ203IMG',
+                   'dict_key': 'vj2_03',
+                'description': 'JPSS2 (NOAA-21) VIIRS (375m) Geolocation Fields Product',
+                    'website': 'https://doi.org/10.5067/VIIRS/VJ203IMG.021',
+                  'satellite': 'NOAA21',
+                 'instrument': 'VIIRS',
+                  'reference': 'VCST Team. VIIRS/JPSS2 Imagery Resolution Terrain-Corrected Geolocation 6-Min L1 Swath 375m Light. Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VJ203IMG.021',
+                },
+
+        'VNP03MOD': {
+                'dataset_tag': '5200/VNP03MOD',
+                   'dict_key': 'vnp_03',
+                'description': 'Suomi-NPP VIIRS (750m) Geolocation Fields Product',
+                    'website': 'https://doi.org/10.5067/VIIRS/VNP03MOD.002',
+                  'satellite': 'SNPP',
+                 'instrument': 'VIIRS',
+                  'reference': 'VCST Team. 2021-07-12. VIIRS/NPP Moderate Resolution Terrain-Corrected Geolocation L1 6-Min Swath 750 m. Version 2. LAADS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VNP03MOD.002',
+                },
+
+        'VJ103MOD': {
+                'dataset_tag': '5201/VJ103MOD',
+                   'dict_key': 'vj1_03',
+                'description': 'JPSS1 (NOAA-20) VIIRS (750m) Geolocation Fields Product',
+                    'website': 'https://doi.org/10.5067/VIIRS/VJ103MOD.021',
+                  'satellite': 'NOAA20',
+                 'instrument': 'VIIRS',
+                  'reference': 'VCST Team. 2019-08-01. VIIRS/JPSS1 Moderate Resolution Terrain Corrected Geolocation 6-Min L1 Swath 750m. Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VJ103MOD.002',
+                },
+
+         'VJ203MOD': {
+                'dataset_tag': '5200/VJ203MOD',
+                   'dict_key': 'vj2_03',
+                'description': 'JPSS2 (NOAA-21) VIIRS (750m) Geolocation Fields Product',
+                    'website': 'https://doi.org/10.5067/VIIRS/VJ203MOD.021',
+                  'satellite': 'NOAA21',
+                 'instrument': 'VIIRS',
+                  'reference': 'VCST Team. 2019-08-01. VIIRS/JPSS1 Moderate Resolution Terrain Corrected Geolocation 6-Min L1 Swath 750m. Version 2. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS). https://doi.org/10.5067/VIIRS/VJ203MOD.002',
+                },
+
+        'VNPRGB': {
+                'dataset_tag': '5200/VNPRGB',
+                   'dict_key': 'vnp_rgb',
+                'description': 'Suomi-NPP VIIRS True Color (RGB) Imagery',
+                    'website': 'https://worldview.earthdata.nasa.gov',
+                  'satellite': 'SNPP',
+                 'instrument': 'VIIRS',
+                  'reference': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
+                },
+
+        'VJ1RGB': {
+                'dataset_tag': '5201/VJ1RGB',
+                   'dict_key': 'vj1_rgb',
+                'description': 'JPSS1 (NOAA-20) VIIRS True Color (RGB) Imagery',
+                    'website': 'https://worldview.earthdata.nasa.gov',
+                  'satellite': 'NOAA20',
+                 'instrument': 'VIIRS',
+                  'reference': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
+                },
+
+        'VJ2RGB': {
+                'dataset_tag': '5200/VJ2RGB',
+                   'dict_key': 'vj2_rgb',
+                'description': 'JPSS2 (NOAA-21) VIIRS True Color (RGB) Imagery',
+                    'website': 'https://worldview.earthdata.nasa.gov',
+                  'satellite': 'NOAA21',
+                 'instrument': 'VIIRS',
+                  'reference': 'We acknowledge the use of imagery from the NASA Worldview application (https://worldview.earthdata.nasa.gov/), part of the NASA Earth Observing System Data and Information System (EOSDIS).',
+                },
+
+        'VNP_CLDPROP_L2': {
+                'dataset_tag': '5111/CLDPROP_L2_VIIRS_SNPP',
+                   'dict_key': 'vnp_l2',
+                'description': 'Suomi-NPP VIIRS Cloud Properties Product',
+                    'website': 'https://doi.org/10.5067/VIIRS/CLDPROP_L2_VIIRS_SNPP.011',
+                  'satellite': 'SNPP',
+                 'instrument': 'VIIRS',
+                  'reference': 'NASA VIIRS Atmosphere SIPS. 2019-11-15. VIIRS/SNPP Cloud Properties 6-min L2 Swath 750m. Version 1.1. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS).',
+                },
+
+        'VJ1_CLDPROP_L2': {
+                'dataset_tag': '5111/CLDPROP_L2_VIIRS_NOAA20',
+                   'dict_key': 'vj1_l2',
+                'description': 'JPSS1 (NOAA-20) VIIRS Cloud Properties Product',
+                    'website': 'https://ladsweb.modaps.eosdis.nasa.gov/missions-and-measurements/products/CLDPROP_L2_VIIRS_NOAA20',
+                  'satellite': 'NOAA20',
+                 'instrument': 'VIIRS',
+                  'reference': 'NASA VIIRS Atmosphere SIPS. 2019-11-15. VIIRS/JPSS1 Cloud Properties 6-min L2 Swath 750m. Version 1.1. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS).',
+                },
+
+        ## commenting this out as cloud products for NOAA-21 are not available yet
+        # 'VJ2_CLDPROP_L2': {
+        #         'dataset_tag': '5111/CLDPROP_L2_VIIRS_NOAA21',
+        #            'dict_key': 'vj2_l2',
+        #         'description': 'JPSS2 (NOAA-21) VIIRS Cloud Properties Product',
+        #             'website': 'https://ladsweb.modaps.eosdis.nasa.gov/missions-and-measurements/products/CLDPROP_L2_VIIRS_NOAA21',
+        #           'satellite': 'NOAA21',
+        #          'instrument': 'VIIRS',
+        #           'reference': 'NASA VIIRS Atmosphere SIPS. 2019-11-15. VIIRS/JPSS2 Cloud Properties 6-min L2 Swath 750m. Version 1.1. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS).',
+        #         },
+
+        'oco2_L1bScND': {
+                'dataset_tag': 'oco2_L1bScND',
+                   'dict_key': 'oco_l1b',
+                'description': 'OCO-2 L1B Calibrated Radiances Product',
+                    'website': 'https://doi.org/10.5067/6O3GEUK7U2JG',
+                  'satellite': 'OCO-2',
+                 'instrument': 'OCO-2',
+                  'reference': 'OCO-2 Science Team/Gunson, M., and Eldering, A.: OCO-2 Level 1B calibrated, geolocated science spectra, Retrospective Processing V10r, Goddard Earth Sciences Data and Information Services Center (GES DISC) [data set], Greenbelt, MD, USA, https://doi.org/10.5067/6O3GEUK7U2JG (last access: %s), 2019.' % _date_today_,
+                },
+
+        'oco2_L2MetND': {
+                'dataset_tag': 'oco2_L2MetND',
+                   'dict_key': 'oco_met_l2',
+                'description': 'OCO-2 L2 Meteorological Parameters Product',
+                    'website': 'https://doi.org/10.5067/OJZZW0LIGSDH',
+                  'satellite': 'OCO-2',
+                 'instrument': 'OCO-2',
+                  'reference': 'OCO-2 Science Team/Gunson, M., and Eldering, A.: OCO-2 Level 2 meteorological parameters interpolated from global assimilation model for each sounding, Retrospective Processing V10r, Goddard Earth Sciences Data and Information Services Center (GES DISC) [data set], Greenbelt, MD, USA, https://doi.org/10.5067/OJZZW0LIGSDH (last access: %s), 2019.' % _date_today_,
+                },
+
+        'oco2_L2StdND': {
+                'dataset_tag': 'oco2_L2StdND',
+                   'dict_key': 'oco_ret_l2',
+                'description': 'OCO-2 L2 XCO2 Retrieval Product',
+                    'website': 'https://doi.org/10.5067/6SBROTA57TFH',
+                  'satellite': 'OCO-2',
+                 'instrument': 'OCO-2',
+                  'reference': 'OCO-2 Science Team/Gunson, M., and Eldering, A.: OCO-2 Level 2 geolocated XCO2 retrievals results, physical model, Retrospective Processing V10r, Goddard Earth Sciences Data and Information Services Center (GES DISC) [data set], Greenbelt, MD, USA, https://doi.org/10.5067/6SBROTA57TFH (last access: %s), 2020.' % _date_today_,
+                },
+
+        }
+#\----------------------------------------------------------------------------/#

--- a/er3t/common.py
+++ b/er3t/common.py
@@ -201,6 +201,51 @@ _sat_tags_support_ = {
                   'reference': 'Ackerman, S., P. Menzel, R. Frey, B.Baum, 2017. MODIS Atmosphere L2 Cloud Mask Product. NASA MODIS Adaptive Processing System, Goddard Space Flight Center, [doi:10.5067/MODIS/MYD35_L2.061]'
                 },
 
+        # uncomment when product becomes available
+        # 'MOD_CLDMSK_L2': {
+        #         'dataset_tag': '5110/CLDMSK_L2_MODIS_Terra',
+        #            'dict_key': 'mod_cldmsk_l2',
+        #         'description': 'MODIS/Terra Cloud Mask 5-Min Swath 1 km',
+        #                 'doi': '10.5067/MODIS/CLDMSK_L2_MODIS_Terra.001',
+        #             'website': 'https://ladsweb.modaps.eosdis.nasa.gov/missions-and-measurements/products/CLDMSK_L2_MODIS_Terra',
+        #           'satellite': 'Terra',
+        #          'instrument': 'MODIS',
+        #           'reference': 'Ackerman, S., et al., 2019. MODIS/Terra Cloud Mask and Spectral Test Results 5-Min L2 Swath 1km, Version-1. NASA Level-1 and Atmosphere Archive & Distribution System (LAADS) Distributed Active Archive Center (DAAC), Goddard Space Flight Center, USA: https://dx.doi.org/10.5067/VIIRS/ CLDMSK_L2_MODIS_Terra.001',
+        #         },
+
+        # 'TERRA_CLDMSK_L2': {
+        #         'dataset_tag': '5110/CLDMSK_L2_MODIS_Terra',
+        #            'dict_key': 'mod_cldmsk_l2',
+        #         'description': 'MODIS/Terra Cloud Mask 5-Min Swath 1 km',
+        #                 'doi': '10.5067/MODIS/CLDMSK_L2_MODIS_Terra.001',
+        #             'website': 'https://ladsweb.modaps.eosdis.nasa.gov/missions-and-measurements/products/CLDMSK_L2_MODIS_Terra',
+        #           'satellite': 'Terra',
+        #          'instrument': 'MODIS',
+        #           'reference': 'Ackerman, S., et al., 2019. MODIS/Terra Cloud Mask and Spectral Test Results 5-Min L2 Swath 1km, Version-1. NASA Level-1 and Atmosphere Archive & Distribution System (LAADS) Distributed Active Archive Center (DAAC), Goddard Space Flight Center, USA: https://dx.doi.org/10.5067/VIIRS/ CLDMSK_L2_MODIS_Terra.001',
+        #         },
+
+        'MYD_CLDMSK_L2': {
+                'dataset_tag': '5110/CLDMSK_L2_MODIS_Aqua',
+                   'dict_key': 'myd_cldmsk_l2',
+                'description': 'MODIS/Aqua Cloud Mask 5-Min Swath 1 km',
+                        'doi': '10.5067/MODIS/CLDMSK_L2_MODIS_Aqua.001',
+                    'website': 'https://ladsweb.modaps.eosdis.nasa.gov/missions-and-measurements/products/CLDMSK_L2_MODIS_Aqua',
+                  'satellite': 'Aqua',
+                 'instrument': 'MODIS',
+                  'reference': 'Ackerman, S., et al., 2019. MODIS/Aqua Cloud Mask and Spectral Test Results 5-Min L2 Swath 1km, Version-1. NASA Level-1 and Atmosphere Archive & Distribution System (LAADS) Distributed Active Archive Center (DAAC), Goddard Space Flight Center, USA: https://dx.doi.org/10.5067/VIIRS/CLDMSK_L2_MODIS_Aqua.001',
+                },
+
+        'AQUA_CLDMSK_L2': {
+                'dataset_tag': '5110/CLDMSK_L2_MODIS_Aqua',
+                   'dict_key': 'myd_cldmsk_l2',
+                'description': 'MODIS/Aqua Cloud Mask 5-Min Swath 1 km',
+                        'doi': '10.5067/MODIS/CLDMSK_L2_MODIS_Aqua.001',
+                    'website': 'https://ladsweb.modaps.eosdis.nasa.gov/missions-and-measurements/products/CLDMSK_L2_MODIS_Aqua',
+                  'satellite': 'Aqua',
+                 'instrument': 'MODIS',
+                  'reference': 'Ackerman, S., et al., 2019. MODIS/Aqua Cloud Mask and Spectral Test Results 5-Min L2 Swath 1km, Version-1. NASA Level-1 and Atmosphere Archive & Distribution System (LAADS) Distributed Active Archive Center (DAAC), Goddard Space Flight Center, USA: https://dx.doi.org/10.5067/VIIRS/CLDMSK_L2_MODIS_Aqua.001',
+                },
+
         'MOD09': {
                 'dataset_tag': '61/MOD09',
                    'dict_key': 'mod_09',
@@ -411,6 +456,39 @@ _sat_tags_support_ = {
         #          'instrument': 'VIIRS',
         #           'reference': 'NASA VIIRS Atmosphere SIPS. 2019-11-15. VIIRS/JPSS2 Cloud Properties 6-min L2 Swath 750m. Version 1.1. MODAPS at NASA/GSFC. Archived by National Aeronautics and Space Administration, U.S. Government, L1 and Atmosphere Archive and Distribution System (LAADS).',
         #         },
+
+        'VNP_CLDMSK_L2': {
+                'dataset_tag': '5110/CLDMSK_L2_VIIRS_SNPP',
+                   'dict_key': 'vnp_cldmsk_l2',
+                'description': 'VIIRS/SNPP Cloud Mask 6-Min Swath 750 m',
+                        'doi': '10.5067/VIIRS/CLDMSK_L2_VIIRS_SNPP.001',
+                    'website': 'https://ladsweb.modaps.eosdis.nasa.gov/missions-and-measurements/products/CLDMSK_L2_VIIRS_SNPP',
+                  'satellite': 'SNPP',
+                 'instrument': 'VIIRS',
+                  'reference': 'Ackerman, S., et al., 2019. VIIRS/SNPP Cloud Mask and Spectral Test Results 6-Min L2 Swath 750m, Version-1. NASA Level-1 and Atmosphere Archive & Distribution System (LAADS) Distributed Active Archive Center (DAAC), Goddard Space Flight Center, USA: https://dx.doi.org/10.5067/VIIRS/CLDMSK_L2_VIIRS_SNPP.001',
+                },
+
+         'VJ1_CLDMSK_L2': {
+                'dataset_tag': '5110/CLDMSK_L2_VIIRS_NOAA20',
+                   'dict_key': 'vj1_cldmsk_l2',
+                'description': 'VIIRS/NOAA20 (JPSS1) Cloud Mask 6-Min Swath 750 m',
+                        'doi': '10.5067/VIIRS/CLDMSK_L2_VIIRS_NOAA20.001',
+                    'website': 'https://ladsweb.modaps.eosdis.nasa.gov/missions-and-measurements/products/CLDMSK_L2_VIIRS_NOAA20',
+                  'satellite': 'NOAA20',
+                 'instrument': 'VIIRS',
+                  'reference': 'Ackerman, S., et al., 2019. VIIRS/NOAA20 Cloud Mask and Spectral Test Results 6-Min L2 Swath 750m, Version-1. NASA Level-1 and Atmosphere Archive & Distribution System (LAADS) Distributed Active Archive Center (DAAC), Goddard Space Flight Center, USA: https://dx.doi.org/10.5067/VIIRS/CLDMSK_L2_VIIRS_NOAA20.001',
+                },
+
+          'VJ2_CLDMSK_L2': {
+                'dataset_tag': '5110/CLDMSK_L2_VIIRS_NOAA21',
+                   'dict_key': 'vj2_cldmsk_l2',
+                'description': 'VIIRS/NOAA21 (JPSS2) Cloud Mask 6-Min Swath 750 m',
+                        'doi': '10.5067/VIIRS/CLDMSK_L2_VIIRS_NOAA21.001',
+                    'website': 'https://ladsweb.modaps.eosdis.nasa.gov/missions-and-measurements/products/CLDMSK_L2_VIIRS_NOAA21',
+                  'satellite': 'NOAA21',
+                 'instrument': 'VIIRS',
+                  'reference': 'Ackerman, S., et al., 2019. VIIRS/NOAA21 Cloud Mask and Spectral Test Results 6-Min L2 Swath 750m, Version-1. NASA Level-1 and Atmosphere Archive & Distribution System (LAADS) Distributed Active Archive Center (DAAC), Goddard Space Flight Center, USA: https://dx.doi.org/10.5067/VIIRS/CLDMSK_L2_VIIRS_NOAA21.001',
+                },
 
         'VNP09': {
                 'dataset_tag': '5200/VNP09',

--- a/er3t/util/daac.py
+++ b/er3t/util/daac.py
@@ -110,7 +110,7 @@ def get_command_earthdata(
         primary_tool='curl',
         backup_tool='wget',
         fdir_save='%s/satfile' % fdir_data_tmp,
-        verbose=1):
+        verbose=False):
 
     """
     Get the LINUX/UNIX download command using curl or wget as the download tool.
@@ -122,21 +122,20 @@ def get_command_earthdata(
 
     fname_save = '%s/%s' % (fdir_save, filename)
 
-
-    if token_mode:
+    if token_mode: # recommended
 
         token = get_token_earthdata()
         header = '"Authorization: Bearer %s"' % token
 
         if verbose:
             options = {
-                    'curl': '--header %s --connect-timeout 120.0 --retry 3 --location --continue-at - --output "%s" "%s"' % (header, fname_save, fname_target),
-                    'wget': '--header=%s --continue --timeout=120 --tries=3 --show-progress --output-document="%s" "%s"' % (header, fname_save, fname_target),
+                    'curl': '--header %s --connect-timeout 60.0 --retry 1 --max-time 60.0 --location --continue-at - --output "%s" "%s"' % (header, fname_save, fname_target),
+                    'wget': '--header=%s --continue --timeout=60 --tries=2 --show-progress --output-document="%s" "%s"' % (header, fname_save, fname_target),
                     }
         else:
             options = {
-                    'curl': '-s --header %s --connect-timeout 120.0 --retry 3 --location --continue-at - "%s" "%s"' % (header, fname_save, fname_target),
-                    'wget': '--header=%s --continue --timeout=120 --tries=3  --quiet --output-document="%s" "%s"' % (header, fname_save, fname_target),
+                    'curl': '-sS --no-progress-bar --header %s --connect-timeout 60.0 --max-time 60.0 --retry 1 --location --continue-at - --output "%s" "%s"' % (header, fname_save, fname_target),
+                    'wget': '--header=%s --continue --timeout=60 --tries=2  --quiet --output-document="%s" "%s"' % (header, fname_save, fname_target),
                     }
 
 
@@ -146,13 +145,13 @@ def get_command_earthdata(
 
         if verbose:
             options = {
-                    'curl': '--netrc --cookie-jar %s --cookie %s --connect-timeout 120.0 --retry 3 --location --continue-at - --output "%s" "%s"' % (secret['cookies'], secret['cookies'], fname_save, fname_target),
-                    'wget': '--continue --load-cookies=%s --save-cookies=%s --auth-no-challenge --keep-session-cookies --content-disposition --timeout=120 --tries=3 --show-progress --output-document="%s" "%s"' % (secret['cookies'], secret['cookies'], fname_save, fname_target),
+                    'curl': '--netrc --cookie-jar %s --cookie %s --connect-timeout 60.0 --max-time 60.0 --retry 1 --location --continue-at - --output "%s" "%s"' % (secret['cookies'], secret['cookies'], fname_save, fname_target),
+                    'wget': '--continue --load-cookies=%s --save-cookies=%s --auth-no-challenge --keep-session-cookies --content-disposition --timeout=60 --tries=2 --show-progress --output-document="%s" "%s"' % (secret['cookies'], secret['cookies'], fname_save, fname_target),
                     }
         else:
             options = {
-                'curl': '-s --netrc --cookie-jar %s --cookie %s --connect-timeout 120.0 --retry 3 --location --continue-at - --output "%s" "%s"' % (secret['cookies'], secret['cookies'], fname_save, fname_target),
-                'wget': '--continue --load-cookies=%s --save-cookies=%s --auth-no-challenge --quiet --keep-session-cookies --content-disposition --timeout=120 --tries=3 --output-document="%s" "%s"' % (secret['cookies'], secret['cookies'], fname_save, fname_target),
+                'curl': '-s --netrc --cookie-jar %s --cookie %s --connect-timeout 60.0 --max-time 60.0 --retry 1 --location --continue-at - --output "%s" "%s"' % (secret['cookies'], secret['cookies'], fname_save, fname_target),
+                'wget': '--continue --load-cookies=%s --save-cookies=%s --auth-no-challenge --quiet --keep-session-cookies --content-disposition --timeout=60 --tries=2 --output-document="%s" "%s"' % (secret['cookies'], secret['cookies'], fname_save, fname_target),
                 }
 
     if not os.path.exists(fdir_save):
@@ -273,12 +272,13 @@ def get_local_file(
 def get_online_file(
         fname_file,
         geometa,
+        csv,
         filename=None,
         download=True,
         primary_tool='curl',
         backup_tool='wget',
         fdir_save='%s/satfile' % fdir_data_tmp,
-        verbose=1):
+        verbose=False):
 
     if filename is None:
         filename = os.path.basename(fname_file)
@@ -297,8 +297,11 @@ def get_online_file(
         # as a last resort, attempt with backup tool.
         try:
             # delete local version of the geometa first as this seems to cause issues downstream
-            if geometa:
+            if (geometa is True) or (csv is True): # they can be None so make True explicit
                 delete_file(fname_file, filename=filename, fdir_save=fdir_save)
+            # if primary_tool == 'wget': # force wget to timeout
+            #     primary_command = "timeout 60 " + primary_command
+
             os.system(primary_command)
             content = get_local_file(fname_file, filename=filename, fdir_save=fdir_save)
         except Exception as message:
@@ -314,13 +317,17 @@ def get_online_file(
                 delete_file(fname_file, filename=filename, fdir_save=fdir_save)
 
                 try:
+                    # if backup_tool == 'wget':
+                    #     backup_command = "timeout 60 " + backup_command
+                    # print("Executing following operation as a backup...\n{}".format(backup_command))
+
                     os.system(backup_command)
                     content = get_local_file(fname_file, filename=filename, fdir_save=fdir_save)
                 except Exception as message:
                     print(message, "\n")
                     msg = "Message [get_online_file]: Failed to download/read {},\nTry again later.".format(fname_file)
                     delete_file(fname_file, filename=filename, fdir_save=fdir_save)
-                    raise OSError(msg)
+                    return None
 
     else:
 
@@ -362,7 +369,6 @@ def get_online_file(
         content = None
 
     return content
-
 
 
 def final_file_check(fname_local, data_format, verbose):
@@ -440,6 +446,7 @@ def final_file_check(fname_local, data_format, verbose):
 
 
 
+
 def read_geometa(content):
 
     """
@@ -476,9 +483,18 @@ def read_geometa(content):
 
     lines = content.split('\n')
 
+    if len(lines) == 1:
+        msg = 'Error [read_geometa]: Could not download the geoMeta text file. This could be an issue with either the download tool or the Earthdata token'
+        if (lines[0][0] == '{') and (lines[0][-1] == '}'):
+            msg = msg + ' or the date for which you are looking to download does not have data.\n'
+
+        print(msg)
+        return None
+
     if lines[0] == '<!DOCTYPE html>' or lines[1] == '<!DOCTYPE html>':
         msg = 'Error [read_geometa]: Could not download the geoMeta text file. This could be an issue with either the download tool or the Earthdata token.\n'
-        raise OSError(msg)
+        print(msg)
+        return None
 
     index_header = 0
     while (len(lines[index_header]) > 0) and lines[index_header][0] == '#':
@@ -488,7 +504,8 @@ def read_geometa(content):
 
     if index_header == -1:
         msg = 'Error [read_geometa]: Cannot locate header in the provided content.\n'
-        raise OSError(msg)
+        print(msg)
+        return None
 
     header_line = lines[index_header]
     vnames = [word.strip() for word in header_line[1:].split(',')]
@@ -525,6 +542,7 @@ def read_geometa(content):
             data.append(data0)
 
     return data
+
 
 
 
@@ -984,7 +1002,7 @@ def get_satfile_tag(
     """
     Get filename tag/overpass information for standard products.
     Currently supported satellites/instruments are:
-    Aqua/MODIS, Terra/MODIS, SNPP/VIIRS, NOAA-20/VIIRS.
+    Aqua/MODIS, Terra/MODIS, SNPP/VIIRS, NOAA-20/VIIRS, NOAA-21/VIIRS.
 
     Input:
         date: Python datetime.datetime object
@@ -1048,7 +1066,7 @@ def get_satfile_tag(
     #     content = get_online_file(fname_geometa, geometa=True, filename=filename_geometa, fdir_save=fdir_save)
 
     # for now, always use online file since local seems to cause downstream issues
-    content = get_online_file(fname_geometa, geometa-True, filename=filename_geometa, fdir_save=fdir_save)
+    content = get_online_file(fname_geometa, geometa=True, csv=None, filename=filename_geometa, fdir_save=fdir_save)
     #\----------------------------------------------------------------------------/#
 
 
@@ -1184,14 +1202,14 @@ def download_laads_https(
 
     # try to get geometa information online
     if content is None:
-        content = get_online_file(fname_csv, geometa=False, filename=filename_csv, fdir_save=fdir_save)
+        content = get_online_file(fname_csv, geometa=False, csv=True, filename=filename_csv, fdir_save=fdir_save)
     #\----------------------------------------------------------------------------/#
 
 
     # get download commands
     #/----------------------------------------------------------------------------\#
-    lines    = content.split('\n')
-
+    exist_count = 0 # to prevent re-downloading. TODO: Add `overwrite` option instead for user
+    lines = content.split('\n')
     primary_commands = []
     backup_commands  = []
     fnames_local = []
@@ -1201,11 +1219,16 @@ def download_laads_https(
         if filename_tag in filename:
             fname_server = '%s/%s' % (fdir_server, filename)
             fname_local  = '%s/%s' % (fdir_out, filename)
-            fnames_local.append(fname_local)
+            if os.path.isfile(fname_local) and final_file_check(fname_local, data_format=data_format, verbose=verbose):
+                print("Message [download_lance_https]: File {} already exists and looks good. Will not re-download this file.".format(fname_local))
+                exist_count += 1
+            else:
+                fnames_local.append(fname_local)
+                primary_command, backup_command = get_command_earthdata(fname_server, filename=filename, fdir_save=fdir_out, verbose=verbose)
+                primary_commands.append(primary_command)
+                backup_commands.append(backup_command)
 
-            primary_command, backup_command = get_command_earthdata(fname_server, filename=filename, fdir_save=fdir_out, verbose=verbose)
-            primary_commands.append(primary_command)
-            backup_commands.append(backup_command)
+    print("Message [download_laads_https]: Total of {} will be downloaded. {} will be skipped as they already exist and work as advertised.".format(len(fnames_local), exist_count))
     #\----------------------------------------------------------------------------/#
 
 
@@ -1221,9 +1244,15 @@ def download_laads_https(
                 print('Message [download_laads_https]: Downloading %s ...' % fname_local)
             os.system(primary_commands[i])
 
+            # if primary command fails, execute backup command.
+            # if that fails again, then delete the file and remove from list
             if not final_file_check(fname_local, data_format=data_format, verbose=verbose):
                 os.system(backup_commands[i])
 
+                if not final_file_check(fname_local, data_format=data_format, verbose=verbose):
+                    print("Message [download_laads_https]: Could not complete the download of or something is wrong with {}...deleting...".format(fname_local))
+                    os.remove(fname_local)
+                    fnames_local.remove(fname_local) #remove from list
     else:
 
         print('Message [download_laads_https]: The commands to run are:')
@@ -1298,14 +1327,14 @@ def download_lance_https(
 
     # try to get geometa information online
     if content is None:
-        content = get_online_file(fname_csv, geometa=False, filename=filename_csv, fdir_save=fdir_save)
+        content = get_online_file(fname_csv, geometa=False, csv=True, filename=filename_csv, fdir_save=fdir_save)
     #\----------------------------------------------------------------------------/#
 
 
     # get download commands
     #/----------------------------------------------------------------------------\#
-    lines    = content.split('\n')
-
+    exist_count = 0
+    lines = content.split('\n')
     primary_commands = []
     backup_commands  = []
     fnames_local = []
@@ -1315,12 +1344,20 @@ def download_lance_https(
         if (filename_tag in filename) and ('.met' not in filename):
             fname_server = '%s/api/v2/content%s/%s' % (server, fdir_data, filename)
             fname_local  = '%s/%s' % (fdir_out, filename)
-            fnames_local.append(fname_local)
 
-            primary_command, backup_command = get_command_earthdata(fname_server, filename=filename, fdir_save=fdir_out, verbose=verbose)
-            primary_commands.append(primary_command)
-            backup_commands.append(backup_command)
+
+            if os.path.isfile(fname_local) and final_file_check(fname_local, data_format=data_format, verbose=verbose):
+                print("Message [download_lance_https]: File {} already exists and looks good. Will not re-download this file.".format(fname_local))
+                exist_count += 1
+            else:
+                fnames_local.append(fname_local)
+                primary_command, backup_command = get_command_earthdata(fname_server, filename=filename, fdir_save=fdir_out, primary_tool='curl', backup_tool='wget', verbose=verbose)
+                primary_commands.append(primary_command)
+                backup_commands.append('timeout 60 ' + backup_command) # force timeout for wget
+
+    print("Message [download_lance_https]: Total of {} will be downloaded. {} will be skipped as they already exist and work as advertised.".format(len(fnames_local), exist_count))
     #\----------------------------------------------------------------------------/#
+
 
 
     # run/print command
@@ -1332,15 +1369,21 @@ def download_lance_https(
             fname_local = fnames_local[i]
 
             if verbose:
-                print('Message [download_laads_https]: Downloading %s ...' % fname_local)
+                print('Message [download_lance_https]: Downloading %s ...' % fname_local)
             os.system(primary_commands[i])
 
+            # if primary command fails, execute backup command.
+            # if that fails again, then delete the file and remove from list
             if not final_file_check(fname_local, data_format=data_format, verbose=verbose):
                 os.system(backup_commands[i])
 
+                if not final_file_check(fname_local, data_format=data_format, verbose=verbose):
+                    print("Message [download_lance_https]: Could not complete the download of or something is wrong with {}...deleting...".format(fname_local))
+                    os.remove(fname_local)
+                    fnames_local.remove(fname_local) #remove from list
     else:
 
-        print('Message [download_laads_https]: The commands to run are:')
+        print('Message [download_lance_https]: The commands to run are:')
         for command in primary_commands:
             print(command)
     #\----------------------------------------------------------------------------/#

--- a/er3t/util/daac.py
+++ b/er3t/util/daac.py
@@ -1059,7 +1059,6 @@ def get_satfile_tag(
 
 
     # get geometa info
-    #/----------------------------------------------------------------------------\#
     filename_geometa = '%s_%s' % (server.replace('https://', '').split('.')[0], os.path.basename(fname_geometa))
 
     # try to get geometa information from local
@@ -1071,13 +1070,13 @@ def get_satfile_tag(
 
     # for now, always use online file since local seems to cause downstream issues
     content = get_online_file(fname_geometa, geometa=True, csv=None, filename=filename_geometa, fdir_save=fdir_save)
-    #\----------------------------------------------------------------------------/#
-
 
     # read in geometa info
-    #/----------------------------------------------------------------------------\#
     data = read_geometa(content)
-    #\----------------------------------------------------------------------------/#
+
+    if data is None:
+        return []
+
 
 
     # loop through all the satellite "granules" constructed through four corner points

--- a/er3t/util/daac.py
+++ b/er3t/util/daac.py
@@ -530,6 +530,10 @@ def read_geometa(content):
                 data0['Satellite']  = 'NOAA-20'
                 data0['Instrument'] = 'VIIRS'
                 data0['Orbit']      = 'Ascending'
+            elif 'VJ203' in data0_[0].split('.')[0]:
+                data0['Satellite']  = 'NOAA-21'
+                data0['Instrument'] = 'VIIRS'
+                data0['Orbit']      = 'Ascending'
             elif 'VNP03' in data0_[0].split('.')[0]:
                 data0['Satellite']  = 'S-NPP'
                 data0['Instrument'] = 'VIIRS'

--- a/er3t/util/modis.py
+++ b/er3t/util/modis.py
@@ -1619,7 +1619,6 @@ class modis_tiff:
         mx  = float(np.max(img))
         img = img/mx
         lon,lat=xx,yy
-        if verb: print(xx.shape,yy.shape,img.shape)
 
         nx,ny,nl = img.shape
         self.img = img
@@ -1965,8 +1964,8 @@ def get_filename_tag(
     try:
         username = os.environ['EARTHDATA_USERNAME']
         password = os.environ['EARTHDATA_PASSWORD']
-    except:
-        exit('Error   [get_filename_tag]: cannot find environment variables \'EARTHDATA_USERNAME\' and \'EARTHDATA_PASSWORD\'.')
+    except Exception as err:
+        exit('Error   [get_filename_tag]: {}\nCannot find environment variables \'EARTHDATA_USERNAME\' and \'EARTHDATA_PASSWORD\'.'.format(err))
 
     try:
         with requests.Session() as session:
@@ -1975,8 +1974,8 @@ def get_filename_tag(
             r      = session.get(r1.url, auth=(username, password))
             if r.ok:
                 content = r.content.decode('utf-8')
-    except:
-        exit('Error   [get_filename_tag]: cannot access \'%s\'.' % fname_server)
+    except Exception as err:
+        exit('Error   [get_filename_tag]: {}\nCannot access {}.'.format(err, fname_server))
 
     dtype = ['|S41','|S16','<i4','<f8','|S1','<f8','<f8','<f8','<f8','<f8','<f8','<f8','<f8','<f8','<f8','<f8','<f8']
     data  = np.genfromtxt(StringIO(content), delimiter=',', skip_header=2, names=True, dtype=dtype)

--- a/er3t/util/modis.py
+++ b/er3t/util/modis.py
@@ -7,7 +7,7 @@ from scipy import interpolate
 import shutil
 import urllib.request
 import requests
-from er3t.util import check_equal, get_doy_tag, get_data_h4, unpack_uint_to_bits
+from er3t.util import check_equal, get_doy_tag, get_data_h4, get_data_nc, unpack_uint_to_bits
 
 
 
@@ -1069,6 +1069,227 @@ class modis_35_l2:
             self.data['land_water_cat']  = dict(name='Land/water category',  data=land_water_cat,  units='N/A')
             self.data['lon_5km']         = dict(name='Longitude at 5km',     data=lon_5km,         units='degrees')
             self.data['lat_5km']         = dict(name='Latitude at 5km',      data=lat_5km,         units='degrees')
+
+
+class modis_mvcm_cldmsk_l2:
+    """
+    A class for extracting data from MODIS/Aqua and MODIS/Terra Cloud Mask 5-Min Swath 1 km files (CLDMSK_L2).
+    This is the Continuity MODIS-VIIRS Cloud Mask (MVCM) and is produced slightly differently from the MxD35_L2 cloud mask product.
+    Consult the references below for appropriate usage.
+
+    Args:
+        fname (str): The file name.
+        mode (str, optional): The mode under which to operate and extract data, one of 'auto' (gets some cloud mask data that should be sufficient for most users) or 'all' (gets all geophysical data). Defaults to 'auto'.
+        quality_assurance (bool, optional): Flag to get QA data. Defaults to False.
+
+    References: (User Guide) https://ladsweb.modaps.eosdis.nasa.gov/api/v2/content/archives/Document%20Archive/Science%20Data%20Product%20Documentation/MODIS_VIIRS_Cloud-Mask_UG_04162020.pdf
+                (ATBD) https://modis-atmosphere.gsfc.nasa.gov/sites/default/files/ModAtmo/MOD35_ATBD_Collection6_0.pdf
+                (Filespec) https://ladsweb.modaps.eosdis.nasa.gov/filespec/VIIRS/1/CLDMSK_L2_MODIS_Aqua
+                (Paper) Frey et al. (2020), https://doi.org/10.3390/rs12203334
+    """
+    ID = 'MODIS MVCM Continuity Cloud Mask 5-Min Swath 1 km'
+
+
+    def __init__(self, \
+                 fname,  \
+                 mode = 'auto', \
+                 quality_assurance = False):
+
+
+        self.fname             = fname              # file name
+        self.mode              = mode.lower()       # mode under which to operate and extract data
+        self.quality_assurance = quality_assurance  # flag to get qa data
+
+        self.read(fname)
+
+
+    def extract_data_byte0(self, dbyte):
+        """
+        Extract cloud mask (in byte format) flags and categories
+        """
+        if dbyte.dtype != 'uint8':
+            dbyte = dbyte.astype('uint8')
+
+        data = unpack_uint_to_bits(dbyte.filled(), 8, bitorder='little')
+        # extract flags and categories (*_cat) bit by bit
+        cloud_mask_flag = data[0]
+        fov_qa_cat      = data[1] + 2 * data[2] # convert to a value between 0 and 3
+        day_night_flag  = data[3]
+        sunglint_flag   = data[4]
+        snow_ice_flag   = data[5]
+        land_water_cat  = data[6] + 2 * data[7] # convert to a value between 0 and 3
+
+        return cloud_mask_flag, day_night_flag, sunglint_flag, snow_ice_flag, land_water_cat, fov_qa_cat
+
+
+    def extract_other_data_bytes(self, dbyte1, dbyte2, dbyte3):
+        """
+        Extract cloud mask (in byte format) flags and categories for bytes 2, 3 and 4 (treated as bytes 1, 2 and 3 here)
+        Note that bytes 5 and 6 are always padded spare and not used.
+        """
+
+        ################## extract byte 1 ##################
+        if dbyte1.dtype != 'uint8':
+            dbyte1 = dbyte1.astype('uint8')
+
+        data_dbyte1 = unpack_uint_to_bits(dbyte1.filled(), 8, bitorder='little') # convert to binary
+
+        # extract flags bit by bit
+        # bit 0 is spare
+        thin_cirrus_flag_solar    = data_dbyte1[1] # thin cirrus detected using solar chanels
+        snow_cover_ancillary_map  = data_dbyte1[2] # snow cover map from anicllary sources
+        thin_cirrus_flag_ir       = data_dbyte1[3] # thin cirrus detected using IR
+        cloud_adjacent_flag       = data_dbyte1[4] # cloud adjacency (cloudy, probably cloudy plus 1-pixel adjacent)
+        cloud_flag_ir_thresh      = data_dbyte1[5] # cloud flag ocean IR threshold
+        # bits 6 and 7 (co2 high cloud tests) are not used for MVCM
+
+        ################## extract byte 2 ##################
+        if dbyte2.dtype != 'uint8':
+            dbyte2 = dbyte2.astype('uint8')
+
+        data_dbyte2 = unpack_uint_to_bits(dbyte2.filled(), 8, bitorder='little') # convert to binary
+
+        high_cloud_flag_138       = data_dbyte2[0] # 1.38 micron high cloud test
+        high_cloud_flag_ir_night  = data_dbyte2[1] # night only IR high cloud test
+        cloud_flag_ir_temp_diff   = data_dbyte2[2] # Cloud Flag - IR Temperature Difference Tests
+        cloud_flag_ir_night       = data_dbyte2[3] # Cloud Flag – 3.9-11 μm test
+        cloud_flag_vnir_ref       = data_dbyte2[4] # Cloud Flag – VNIR Reflectance Test
+        cloud_flag_vnir_ref_ratio = data_dbyte2[5] # Cloud Flag – VNIR Reflectance Ratio Test
+        clr_sky_ndvi_coastal      = data_dbyte2[6] # clear-sky restoral test – NDVI in coastal areas
+        cloud_flag_water_1621     = data_dbyte2[7] # Cloud Flag – Water 1.6 or 2.1 μm Test
+
+        ################## extract byte 3 ##################
+        if dbyte3.dtype != 'uint8':
+            dbyte3 = dbyte3.astype('uint8')
+
+        data_dbyte3 = unpack_uint_to_bits(dbyte3.filled(), 8, bitorder='little') # convert to binary
+
+        cloud_flag_water_ir                  = data_dbyte3[0] # Cloud Flag – Water 8.6-11 μm
+        clr_sky_ocean_spatial                = data_dbyte3[1] # Clear-sky Restoral Test – Spatial Consistency (ocean)
+        clr_sky_polar_night_land_sunglint    = data_dbyte3[2] # Clear-sky Restoral Tests (polar night, land, sun glint)
+        cloud_flag_sfc_temp_water_night_land = data_dbyte3[3] # Cloud Flag – Surface Temperature Tests (water, night land)
+        # bits 4 and 5 are spare
+        cloud_flag_night_ocean_ir_variable   = data_dbyte3[6] # Cloud Flag – Night Ocean 11 μm Variability Test
+        cloud_flag_night_ocean_low_emissive  = data_dbyte3[7] # Cloud Flag – Night Ocean “Low-Emissivity” 3.9-11 μm Test
+
+        ################## stacking ##################
+        # now stack them by type instead of separate fields
+        cloud_flag_tests  = np.stack([cloud_flag_ir_temp_diff, cloud_flag_ir_night, cloud_flag_vnir_ref, cloud_flag_vnir_ref_ratio, cloud_flag_water_1621, cloud_flag_water_ir, cloud_flag_sfc_temp_water_night_land, cloud_flag_night_ocean_ir_variable, cloud_flag_night_ocean_low_emissive, cloud_flag_ir_thresh, thin_cirrus_flag_solar, thin_cirrus_flag_ir, cloud_adjacent_flag], axis=0)
+
+        self.cloud_flag_test_description = 'index 0: Cloud Flag - IR Temperature Difference Tests\n'\
+                                           'index 1: Cloud Flag - 3.9-11 μm test\n'\
+                                           'index 2: Cloud Flag - VNIR Reflectance Test\n'\
+                                           'index 3: Cloud Flag - VNIR Reflectance Ratio Test\n'\
+                                           'index 4: Cloud Flag - Water 1.6 or 2.1 μm Test\n'\
+                                           'index 5: Cloud Flag - Water 8.6-11 μm\n'\
+                                           'index 6: Cloud Flag - Surface Temperature Tests (water, night land)\n'\
+                                           'index 7: Cloud Flag - Night Ocean 11 μm Variability Test\n'\
+                                           'index 8: Cloud Flag - Night Ocean “Low-Emissivity” 3.9-11 μm Test\n'\
+                                           'index 9: Cloud Flag - IR Threshold\n'\
+                                           'index 10: Cloud Flag - Thin Cirrus (Solar)\n'\
+                                           'index 11: Cloud Flag - Thin Cirrus (IR)\n'\
+                                           'index 12: Cloud Flag - Adjacency Test (cloudy, probably cloudy plus 1-pixel adjacent)\n'\
+
+        high_cloud_flag_tests = np.stack([high_cloud_flag_138, high_cloud_flag_ir_night], axis=0)
+        self.high_cloud_flag_tests_description = 'index 0: 1.38 μm high cloud test\n'\
+                                                 'index 1: night only IR high cloud test\n'\
+
+        clr_sky_restoral_tests = np.stack([clr_sky_ndvi_coastal, clr_sky_ocean_spatial, clr_sky_polar_night_land_sunglint], axis=0)
+        self.clr_sky_restoral_tests_description = 'index 0: Clear-sky Restoral Test - NDVI in coastal areas\n'\
+                                                  'index 1: Clear-sky Restoral Test - Spatial Consistency (ocean)\n'\
+                                                  'index 2: Clear-sky Restoral Tests (polar night, land, sun glint)\n'\
+
+        return cloud_flag_tests, high_cloud_flag_tests, clr_sky_restoral_tests, snow_cover_ancillary_map
+
+
+    def quality_assurance_byte0(self, dbyte):
+        """
+        Extract cloud mask QA byte 1 (treated as byte 0 here)
+        """
+        if dbyte.dtype != 'uint8':
+            dbyte = dbyte.astype('uint8')
+
+        data = unpack_uint_to_bits(dbyte.filled(), 8, bitorder='little')
+
+        # process qa flags
+        # Byte 0 only has 4 bits of useful information, other 4 are always 0
+        useful_qa = data[0] # usefulness QA flag
+        confidence_qa = data[1] + 2 * data[2] + 4 * data[3] # convert to a value between 0 and 7 confidence
+
+        return useful_qa, confidence_qa
+
+
+    def quality_assurance_byte1(self, dbyte):
+        """
+        Extract cloud mask QA byte 2 (treated as byte 1 here).
+        Note that only some bits are extracted as most other data is already available
+        in the main geophysical field data.
+        """
+        if dbyte.dtype != 'uint8':
+            dbyte = dbyte.astype('uint8')
+
+        data = unpack_uint_to_bits(dbyte.filled(), 8, bitorder='little')
+        nco_flag = data[0]
+
+        return nco_flag
+
+
+    def read(self, fname):
+        try:
+            import netCDF4 as nc
+        except ImportError:
+            msg = 'Warning [modis_09]: To use \'modis_09\', \'netCDF4\' needs to be installed.'
+            raise ImportError(msg)
+
+        f = nc.Dataset(fname, 'r')
+
+        # by default clr sky confidence and cloud mask will be extracted
+        clr_sky_confidence = get_data_nc(f['geophysical_data/Clear_Sky_Confidence'], replace_fill_value=np.nan)
+        cloud_mask = get_data_nc(f['geophysical_data/Integer_Cloud_Mask'], replace_fill_value=-1).astype('int8')
+
+        # save the data
+        self.data = {}
+        self.data['clr_sky_confidence'] = dict(name='Clear Sky Confidence', data=clr_sky_confidence, description='The `Clear_Sky_Confidence` is the final numeric value of the confidence of clear sky, or Q value', units='N/A')
+        self.data['cloud_mask']         = dict(name='Cloud Mask',           data=cloud_mask,  description='MODIS cloud mask bits 1 & 2 converted to integer\n(0 = cloudy,\n1= probably cloudy,\n2 = probably clear,\n3 = confident clear,\n-1 = no result)\n', units='N/A')
+
+
+        if (self.mode == 'auto') or (self.mode == 'all'): # extract other data bytes too
+            cloud_mask_tests = f['geophysical_data/Cloud_Mask'] # spectral tests
+            cloud_mask_tests_dat = get_data_nc(cloud_mask_tests, replace_fill_value=None)
+            cloud_mask_flag, day_night_flag, sunglint_flag, snow_ice_flag, land_water_cat, fov_qa_cat = self.extract_data_byte0(cloud_mask_tests_dat[0])
+
+            # save the data
+            self.data['cloud_mask_flag'] = dict(name='Cloud Mask Flag', data=cloud_mask_flag, units='N/A')
+            self.data['day_night_flag']  = dict(name='Day Night Flag',   data=day_night_flag, units='N/A')
+            self.data['sunglint_flag']   = dict(name='Sunglint Flag',   data=sunglint_flag, units='N/A')
+            self.data['snow_ice_flag']   = dict(name='Snow/ice processing path', data=snow_ice_flag, units='N/A')
+            self.data['land_water_flag'] = dict(name='Land/water processing path', data=land_water_cat, units='N/A')
+            self.data['fov_flag']        = dict(name='Unobstructed FOV Quality Flag', data=fov_qa_cat, units='N/A')
+
+            if self.mode == 'all':
+                cloud_flag_tests, high_cloud_flag_tests, clr_sky_restoral_tests, snow_cover_ancillary_map = self.extract_other_data_bytes(cloud_mask_tests_dat[1], cloud_mask_tests_dat[2], cloud_mask_tests_dat[3])
+
+                # save the data
+                self.data['cloud_flag_tests'] = dict(name='Cloud Flags from spectral tests',              data=cloud_flag_tests, description=self.cloud_flag_test_description, units='N/A')
+                self.data['high_cloud_flag_tests'] = dict(name='High Cloud Flags from spectral tests',    data=high_cloud_flag_tests, description=self.high_cloud_flag_tests_description, units='N/A')
+                self.data['clr_sky_restoral_tests'] = dict(name='Clear sky restoral from spectral tests', data=clr_sky_restoral_tests, description=self.clr_sky_restoral_tests_description, units='N/A')
+                self.data['snow_cover_ancillary_map'] = dict(name='Snow cover from ancillary map',        data=snow_cover_ancillary_map, units='N/A')
+
+        # get QA data
+        if self.quality_assurance:
+            nc_qa = f['geophysical_data/Quality_Assurance']
+            qa_dat = get_data_nc(nc_qa, replace_fill_value=None)
+            # transpose because for whatever reason this is in reverse order
+            qa_dat = np.transpose(qa_dat, axes=(2, 0, 1))
+
+            useful_qa, confidence_qa = self.quality_assurance_byte0(qa_dat[0])
+            nco_qa = self.quality_assurance_byte1(qa_dat[1])
+
+            # save the data
+            self.qa = {}
+            self.qa['useful_qa']     = dict(name='Cloud Mask QA', data=useful_qa, units='N/A')
+            self.qa['confidence_qa'] = dict(name='Cloud Mask Confidence QA (8 confidence levels)', data=confidence_qa, units='N/A')
+            self.qa['nco_flag']      = dict(name='Non cloud obstruction QA flag', data=nco_qa, units='N/A')
 
 
 

--- a/er3t/util/modis.py
+++ b/er3t/util/modis.py
@@ -1073,7 +1073,7 @@ class modis_35_l2:
 
 class modis_mvcm_cldmsk_l2:
     """
-    A class for extracting data from MODIS/Aqua and MODIS/Terra Cloud Mask 5-Min Swath 1 km files (CLDMSK_L2).
+    A class for extracting data from MODIS/Aqua Cloud Mask 5-Min Swath 1 km files (CLDMSK_L2).
     This is the Continuity MODIS-VIIRS Cloud Mask (MVCM) and is produced slightly differently from the MxD35_L2 cloud mask product.
     Consult the references below for appropriate usage.
 
@@ -1086,6 +1086,8 @@ class modis_mvcm_cldmsk_l2:
                 (ATBD) https://modis-atmosphere.gsfc.nasa.gov/sites/default/files/ModAtmo/MOD35_ATBD_Collection6_0.pdf
                 (Filespec) https://ladsweb.modaps.eosdis.nasa.gov/filespec/VIIRS/1/CLDMSK_L2_MODIS_Aqua
                 (Paper) Frey et al. (2020), https://doi.org/10.3390/rs12203334
+
+    Note: MODIS/Terra is not yet supported by MVCM
     """
     ID = 'MODIS MVCM Continuity Cloud Mask 5-Min Swath 1 km'
 

--- a/er3t/util/modis.py
+++ b/er3t/util/modis.py
@@ -393,6 +393,10 @@ class modis_l1b:
                 lat0  = f.select('Latitude')
                 lon0  = f.select('Longitude')
 
+            # band info
+            band_numbers = list(f.select('Band_250M')[:])
+            band_dict = dict(zip(band_numbers, np.arange(0, len(band_numbers))))
+
             lon, lat  = upscale_modis_lonlat(lon0[:], lat0[:], scale=4, extra_grid=False)
             raw0      = f.select('EV_250_RefSB')
             uct0      = f.select('EV_250_RefSB_Uncert_Indexes')
@@ -449,8 +453,8 @@ class modis_l1b:
             uct0      = np.vstack([uct0_250, uct0_500])
 
             # band info
-            band_numbers = f.select('Band_250M')[:] + f.select('Band_500M')[:]
-            band_dict = dict(zip(band_numbers, np.arange(0, band_numbers.size)))
+            band_numbers = list(f.select('Band_250M')[:]) + list(f.select('Band_500M')[:])
+            band_dict = dict(zip(band_numbers, np.arange(0, len(band_numbers))))
 
             do_region = True
 

--- a/er3t/util/modis.py
+++ b/er3t/util/modis.py
@@ -351,7 +351,7 @@ class modis_l1b:
         rad_sca = hdf_dset_250.attributes()['radiance_scales']     + hdf_dset_500.attributes()['radiance_scales']     + hdf_dset_1km_solar.attributes()['radiance_scales'] + hdf_dset_1km_emissive.attributes()['radiance_scales']
         ref_off = hdf_dset_250.attributes()['reflectance_offsets'] + hdf_dset_500.attributes()['reflectance_offsets'] + hdf_dset_1km_solar.attributes()['reflectance_offsets'] + list(np.full(-99, num_emissive_bands))
         ref_sca = hdf_dset_250.attributes()['reflectance_scales']  + hdf_dset_500.attributes()['reflectance_scales']  + hdf_dset_1km_solar.attributes()['reflectance_scales'] + list(np.ones(num_emissive_bands))
-        cnt_off = hdf_dset_250.attributes()['corrected_counts_offsets'] + hdf_dset_500.attributes()['corrected_counts_offsets'] + hdf_dset_1km_solar.attributes()['corrected_counts_offsets'] + list(np.full(-99, num_emissive_bands))
+        cnt_off = hdf_dset_250.attributes()['corrected_counts_offsets'] + hdf_dset_500.attributes()['corrected_counts_offsets'] + hdf_dset_1km_solar.attributes()['corrected_counts_offsets'] + list(np.full(num_emissive_bands, -99))
         cnt_sca = hdf_dset_250.attributes()['corrected_counts_scales'] + hdf_dset_500.attributes()['corrected_counts_scales'] + hdf_dset_1km_solar.attributes()['corrected_counts_scales'] + list(np.ones(num_emissive_bands))
         return rad_off, rad_sca, ref_off, ref_sca, cnt_off, cnt_sca
 

--- a/er3t/util/modis.py
+++ b/er3t/util/modis.py
@@ -1361,7 +1361,8 @@ class modis_09:
                 self.bands = [1, 2, 3, 4, 5, 6, 7]
 
         elif self.resolution == '1km':
-            self.bands = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 26]
+            if self.bands is None:
+                self.bands = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 26]
 
         else:
             raise AttributeError('Error [modis_09]: `resolution` must be one of `250m`, `500m`, or `1km`')

--- a/er3t/util/util.py
+++ b/er3t/util/util.py
@@ -119,8 +119,8 @@ def send_email(
         server.login(sender_email, sender_password)
         server.sendmail(sender_email, [receiver], msg.as_string())
         server.quit()
-    except:
-        raise OSError("Error [send_email]: Failed to send the email.")
+    except Exception as err:
+        raise OSError(err, "Error [send_email]: Failed to send the email.")
 
 
 
@@ -429,11 +429,11 @@ def grid_by_extent(lon, lat, data, extent=None, NxNy=None, method='nearest', fil
         N0 = np.sqrt(lon.size/xy)
 
         Nx = int(N0*(extent[1]-extent[0]))
-        if Nx%2 == 1:
+        if Nx % 2 == 1:
             Nx += 1
 
         Ny = int(N0*(extent[3]-extent[2]))
-        if Ny%2 == 1:
+        if Ny % 2 == 1:
             Ny += 1
     else:
         Nx, Ny = NxNy
@@ -500,11 +500,11 @@ def grid_by_lonlat(lon, lat, data, lon_1d=None, lat_1d=None, method='nearest', f
         N0 = np.sqrt(lon.size/xy)
 
         Nx = int(N0*(extent[1]-extent[0]))
-        if Nx%2 == 1:
+        if Nx % 2 == 1:
             Nx += 1
 
         Ny = int(N0*(extent[3]-extent[2]))
-        if Ny%2 == 1:
+        if Ny % 2 == 1:
             Ny += 1
 
         lon_1d0 = np.linspace(extent[0], extent[1], Nx+1)
@@ -747,7 +747,7 @@ def downscale(ndarray, new_shape, operation='mean'):
         ndarray: numpy array, downscaled array
     """
     operation = operation.lower()
-    if not operation in ['sum', 'mean', 'max']:
+    if operation not in ['sum', 'mean', 'max']:
         raise ValueError('Error [downscale]: Operation of \'%s\' not supported.' % operation)
     if ndarray.ndim != len(new_shape):
         raise ValueError("Error [downscale]: Shape mismatch: {} -> {}".format(ndarray.shape, new_shape))

--- a/er3t/util/util.py
+++ b/er3t/util/util.py
@@ -1130,7 +1130,11 @@ def unpack_uint_to_bits(uint_array, num_bits, bitorder='big'):
     uint_array = uint_array.astype('uint{}'.format(num_bits))
 
     if num_bits == 8: # just use numpy
-        return np.unpackbits(uint_array, bitorder='big', axis=1) # convert to binary
+        bits = np.unpackbits(uint_array.flatten(), bitorder=bitorder)
+        # num_bits has to be the last dimensions to get the right array
+        bits = bits.reshape(list(uint_array.shape) + [num_bits])
+        # now we can transpose
+        return np.transpose(bits, axes=(2, 0, 1))
 
     elif (num_bits == 16) or (num_bits == 32) or (num_bits == 64):
 
@@ -1143,7 +1147,8 @@ def unpack_uint_to_bits(uint_array, num_bits, bitorder='big'):
         bits = np.unpackbits(uint8_array, bitorder='little', axis=1)
 
         # Reshape to match original uint16 array shape with an additional dimension for bits
-        bits = bits.reshape(uint_array.shape + (num_bits,))
+        # note that num_bits must be the last dimension here to get the right reshaped array
+        bits = bits.reshape(list(uint_array.shape) + [num_bits])
 
     else:
         raise ValueError("Only uint8, uint16, uint32, and uint64 dtypes are supported. `num_bits` must be >=8 ")

--- a/er3t/util/util.py
+++ b/er3t/util/util.py
@@ -1044,6 +1044,63 @@ def cal_geodesic_lonlat(lon0, lat0, dist, azimuth):
 
     return lon1, lat1
 
+
+def parse_geojson(geojson_fpath):
+
+    import json
+    with open(geojson_fpath, 'r') as f:
+        data = json.load(f)
+        # n_coords = len(data['features'][0]['geometry']['coordinates'][0])
+
+    coords = data['features'][0]['geometry']['coordinates']
+
+    lons = np.array(coords[0])[:, 0]
+    lats = np.array(coords[0])[:, 1]
+    return lons, lats
+
+
+def region_parser(extent, lons, lats, geojson_fpath):
+
+    if (extent is None) and ((lats is None) or (lons is None)) and (geojson_fpath is None):
+        print('Error [sdown]: Must provide either extent or lon/lat coordinates or a geoJSON file')
+        sys.exit()
+
+    if (extent is not None) and ((lats is not None) or (lons is not None)) and (geojson_fpath is not None):
+        print('Warning [sdown]: Received multiple regions of interest. Only `extent` will be used.')
+        llons = np.linspace(extent[0], extent[1], 100)
+        llats = np.linspace(extent[2], extent[3], 100)
+        return llons, llats
+
+
+    if (extent is not None):
+        if (len(extent) != 4) and ((lats is None) or (lons is None) or (len(lats) == 0) or (len(lons) == 0)):
+            print('Error [sdown]: Must provide either extent with [lon1 lon2 lat1 lat2] or lon/lat coordinates via --lons and --lats')
+            sys.exit()
+
+        # check to make sure extent is correct
+        if (extent[0] >= extent[1]) or (extent[2] >= extent[3]):
+            msg = 'Error [sdown]: The given extents of lon/lat are incorrect: %s.\nPlease check to make sure extent is passed as `lon1 lon2 lat1 lat2` format i.e. West, East, South, North.' % extent
+            print(msg)
+            sys.exit()
+
+        llons = np.linspace(extent[0], extent[1], 100)
+        llats = np.linspace(extent[2], extent[3], 100)
+        return llons, llats
+
+    elif (lats is not None) and (lons is not None):
+        if ((len(lats) == 2) and (len(lons) == 2)) and (lons[0] < lons[1]) and (lats[0] < lats[1]):
+            llons = np.linspace(lons[0], lons[1], 100)
+            llats = np.linspace(lats[0], lats[1], 100)
+            return llons, llats
+        else:
+            print('Error [sdown]: Must provide two coorect bounds each for `--lons` and `--lats`')
+            sys.exit()
+
+
+    elif (geojson_fpath is not None):
+        llons, llats = parse_geojson(geojson_fpath)
+        return llons, llats
+
 #\---------------------------------------------------------------------------/
 
 if __name__ == '__main__':

--- a/er3t/util/util.py
+++ b/er3t/util/util.py
@@ -1117,7 +1117,7 @@ def format_time(total_seconds):
     seconds = total_seconds % 60
     milliseconds = (total_seconds - int(total_seconds)) * 1000
 
-    return (int(hours), int(minutes), int(seconds), milliseconds)
+    return (int(hours), int(minutes), int(seconds), int(milliseconds))
 #\---------------------------------------------------------------------------/
 
 if __name__ == '__main__':

--- a/er3t/util/util.py
+++ b/er3t/util/util.py
@@ -1101,6 +1101,23 @@ def region_parser(extent, lons, lats, geojson_fpath):
         llons, llats = parse_geojson(geojson_fpath)
         return llons, llats
 
+
+def format_time(total_seconds):
+    """
+    Convert seconds to hours, minutes, seconds, and milliseconds.
+
+    Parameters:
+    - total_seconds: The total number of seconds to convert.
+
+    Returns:
+    - A tuple containing hours, minutes, seconds, and milliseconds.
+    """
+    hours = total_seconds // 3600
+    minutes = (total_seconds % 3600) // 60
+    seconds = total_seconds % 60
+    milliseconds = (total_seconds - int(total_seconds)) * 1000
+
+    return (int(hours), int(minutes), int(seconds), milliseconds)
 #\---------------------------------------------------------------------------/
 
 if __name__ == '__main__':

--- a/er3t/util/util.py
+++ b/er3t/util/util.py
@@ -17,7 +17,8 @@ __all__ = ['check_equal', 'check_equidistant', 'send_email', \
            'get_doy_tag', 'add_reference', \
            'combine_alt', 'get_lay_index', 'downscale', 'upscale_2d', 'mmr2vmr', \
            'cal_rho_air', 'cal_sol_fac', 'cal_mol_ext', 'cal_ext', \
-           'cal_r_twostream', 'cal_t_twostream', 'cal_geodesic_dist', 'cal_geodesic_lonlat']
+           'cal_r_twostream', 'cal_t_twostream', 'cal_geodesic_dist', 'cal_geodesic_lonlat', \
+           'format_time', 'region_parser', 'parse_geojson']
 
 
 

--- a/er3t/util/viirs.py
+++ b/er3t/util/viirs.py
@@ -918,8 +918,19 @@ class viirs_cldprop_l2:
 
 
 class viirs_09:
+    """
+    A class for extracting data from VIIRS Atmospherically Corrected Surface Reflectance 6-Min L2 Swath IP 375m, 750m files.
+
+    Args:
+        fname (str): The file name of the MOD09 product.
+        resolution (str): The resolution of the product ('375m' or '750m'). Defaults to '750m'.
+        quality_assurance (str): The type of quality assurance data to retrieve ('auto', 'ancillary', 'all', or None). Defaults to None.
+        bands (list, optional): The list of band names. Defaults to ['M05', 'M04', 'M03'].
 
     # Note: VIIRS 09 products are only available as HDF files (instead of netCDF like most other VIIRS products)
+
+    References: (User Guide): https://viirsland.gsfc.nasa.gov/PDF/VIIRS_Surf_Refl_UserGuide_v2.0.pdf
+    """
     ID = 'VIIRS Atmospherically Corrected Surface Reflectance 6-Min L2 Swath IP 375m, 750m'
 
 
@@ -938,6 +949,7 @@ class viirs_09:
         self.available_product_bands = ['I01', 'I02', 'I03', 'M01', 'M02', 'M03', 'M04', 'M05', 'M07', 'M08', 'M10', 'M11']
         self.read(fname)
 
+    # Methods to extract each QQ/QF byte
     ######################### QF1 #########################
     def qa_qf1_viirs_09(self, hdf_obj):
         fdata = hdf_obj.select('QF1 Surface Reflectance')[:]


### PR DESCRIPTION
Highlights from this PR:

New:
    - Readers for MODIS and VIIRS `09` product (atmospherically corrected surface reflectance) 
    - Readers for the MODIS-VIIRS Continuity Cloud Mask (MVCM) (`CLDMSK_L2`)
    - `sdown` now supports MVCM, 09 products as well as NOAA-21 products (those that are available at least) from the LAADS server
    - `sdown` has a parallelization feature to take advantage of multiple CPUs. Users can simply pass `--parallel` to use this feature (only enabled when downloading multiple days of data)

Updates:
    - Many readers now support a `keep_dims` argument to retain original shape of the data (and essentially ignoring the `extent` argument)
    - QA feature extraction from products is updated across many readers
    - Move and update list of products supported by `sdown` to `er3t/common.py`